### PR TITLE
Add support for metadata file parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Tekton tasks and supporting tooling for building multi-architecture Operator Ind
 ```
 .
 ├── Containerfile.iib-build-task          # Container image used by the Tekton task
+├── pyproject.toml                        # Project metadata and test dependencies
 ├── task/
 │   └── iib-image-builder-oci-ta/
 │       ├── iib-image-builder-oci-ta.yaml # Tekton Task definition
@@ -22,14 +23,17 @@ Tekton tasks and supporting tooling for building multi-architecture Operator Ind
 
 ## Task overview
 
-`iib-image-builder-oci-ta` builds source code into multi-architecture Operator Index Images. It:
+`iib-image-builder-oci-ta` builds Operator Index Images from a Trusted Artifact. It:
 
 1. Extracts the source from a Trusted Artifact (`use-trusted-artifact` step)
-2. Generates an OPM cache from the file-based catalog
-3. Builds container images for each target architecture (amd64, arm64, ppc64le, s390x) via `buildah bud`
-4. Creates and pushes a multi-architecture manifest list
+2. Loads build settings from `.iib-build-metadata.json` (`opm_version`, `arches`, `labels`, `binary_image`)
+3. Generates an OPM cache from the file-based catalog under `configs/`
+4. Builds container images for each target architecture via `buildah bud`
+5. Creates and pushes a multi-architecture manifest list
 
-See [`task/iib-image-builder-oci-ta/README.md`](task/iib-image-builder-oci-ta/README.md) for parameter reference and usage examples.
+Index build settings come from the IIB build metadata file in the source tree. Tekton parameters (`IMAGE`, `COMMIT_SHA`, `CONTEXT`, `DOCKERFILE`, …) control where and how the build runs.
+
+See [`task/iib-image-builder-oci-ta/README.md`](task/iib-image-builder-oci-ta/README.md) for parameter reference, metadata format, and TaskRun examples.
 
 ---
 
@@ -112,12 +116,14 @@ pytest -l
 import multi_arch_builder as mab
 ```
 
-It also provides two session-scoped fixtures used across unit tests:
+Shared fixtures:
 
 | Fixture | Description |
 |---|---|
 | `build_config` | A minimal, valid `BuildConfig` instance |
 | `builder` | A `MultiArchBuilder` instance backed by `build_config` |
+| `sample_iib_metadata` | Example IIB build metadata JSON object |
+| `metadata_build_context` | Temp directory with `.iib-build-metadata.json` and Tekton env vars set |
 
 ### `tests/unit/test_multi_arch_builder.py`
 
@@ -127,14 +133,20 @@ Unit tests for every public function and class in `multi-arch-builder.py`. Exter
 |---|---|
 | `TestRegexReverseSearch` | Match ordering (bottom-up iteration), empty stderr, no-match |
 | `TestRunCmd` | Successful execution, default params, strict vs non-strict mode, buildah manifest-rm "image not known", HTTP 403/50x and closed-pipe → `ExternalServiceError`, opm error regex → `IIBError` |
-| `TestGenerateCacheLocally` | OPM command arguments, pre-existing cache cleanup, empty cache → `IIBError`, non-existent cache dir → `IIBError`, `OPM_VERSION` env var |
+| `TestGenerateCacheLocally` | OPM command arguments, pre-existing cache cleanup, empty cache → `IIBError`, non-existent cache dir → `IIBError` |
 | `TestBuildConfig` | Default `arch_map`, custom `arch_map` |
 | `TestValidateDockerfile` | Existing Dockerfile → `True`, missing → `False` |
 | `TestUpdateCATrust` | Skips when bundle absent, copies and updates when present, re-raises `IIBError` |
 | `TestVerifyImageArchitecture` | Matching arch, mismatched arch → `ExternalServiceError`, missing key skips check, custom `arch_map`, `containers-storage:` scheme in inspect command |
-| `TestBuildImage` | buildah flags (`--override-arch`, `--arch`, `--tls-verify`, etc.), label injection, context path appended last, `ExternalServiceError` on network failure |
+| `TestBuildImage` | buildah flags (`--override-arch`, `--arch`, `--tls-verify`, etc.), label injection, `BINARY_IMAGE` build arg, context path appended last, `ExternalServiceError` on network failure |
 | `TestCreateAndPushManifestList` | Tag count with and without `commit_sha`, tolerates "Manifest list not found locally", unexpected rm error re-raises, push uses `--all` and `docker://` scheme |
-| `TestLoadConfigFromEnv` | Defaults for all env vars, relative vs absolute CONTEXT and DOCKERFILE, comma-split PLATFORMS |
+| `TestResolveIibBuildMetadataPath` | Absolute vs relative metadata path resolution |
+| `TestLoadIibBuildMetadata` | Valid JSON load, missing file, invalid JSON, non-object root |
+| `TestOpmVersionFromMetadata` | Normalization of `opm-` prefix |
+| `TestLabelsFromMetadata` | Object → `key=value` list, invalid type → `IIBError` |
+| `TestArchesFromMetadata` | Valid arch list, empty/invalid → `IIBError` |
+| `TestBinaryImageFromMetadata` | Valid string, empty/invalid → `IIBError` |
+| `TestLoadConfigFromEnv` | Values from metadata file, custom metadata path, relative/absolute `CONTEXT` and `DOCKERFILE`, default `CACHE_DIR`, missing `opm_version`/`arches` → `IIBError` |
 | `TestMain` | Missing IMAGE exits 1, missing COMMIT_SHA exits 1, prints JSON to stdout, writes JSON to file, exits 1 on `IIBError` |
 
 ### `tests/tekton/test_iib_image_builder_task.py`
@@ -144,11 +156,11 @@ Structural validation of `iib-image-builder-oci-ta.yaml` using `pyyaml`. No Kube
 | Test class | What is covered |
 |---|---|
 | `TestTaskStructure` | `apiVersion`, `kind`, `name`, description, annotations, labels |
-| `TestTaskParameters` | Required params have no default, optional params have correct defaults, all params have `type` and `description`, PLATFORMS default covers all four architectures |
+| `TestTaskParameters` | Required params (`IMAGE`, `SOURCE_ARTIFACT`), optional defaults including `IIB_BUILD_METADATA_FILE_PATH` |
 | `TestTaskResults` | `IMAGE_DIGEST`, `IMAGE_REF`, `IMAGE_URL` present and described |
 | `TestTaskVolumes` | All five volumes present, `trusted-ca` uses ConfigMap with `optional: true`, others are `emptyDir` |
-| `TestStepTemplate` | Memory limit, CPU request, required env vars (`IMAGE`, `COMMIT_SHA`, `PLATFORMS`, `OPM_VERSION`, `CACHE_DIR`), `shared` and `workdir` volume mounts |
-| `TestTaskSteps` | Both steps present, `use-trusted-artifact` references `SOURCE_ARTIFACT`, `build-multi-arch` script invokes the Python builder, extracts all three results, mounts `varlibcontainers` and `trusted-ca`, runs as root with `SETFCAP`, passes `--ca-bundle`, uses `set -euo pipefail` |
+| `TestStepTemplate` | Memory limit, CPU request, env vars (`IMAGE`, `COMMIT_SHA`, `IIB_BUILD_METADATA_FILE_PATH`, `CACHE_DIR`), `shared` and `workdir` volume mounts |
+| `TestTaskSteps` | Both steps present, `use-trusted-artifact` references `SOURCE_ARTIFACT`, `build-multi-arch` script invokes the Python builder with `--iib-build-metadata-file-path`, extracts all three results, mounts `varlibcontainers` and `trusted-ca`, runs as root with `SETFCAP`, passes `--ca-bundle`, uses `set -euo pipefail` |
 
 ---
 
@@ -161,9 +173,12 @@ buildah build -f Containerfile.iib-build-task -t iib-build-task:latest .
 ```
 
 The image is based on `quay.io/konflux-ci/buildah-task` and bundles:
+
 - Multiple OPM versions (v1.26.4, v1.40.0, v1.44.0, v1.48.0)
 - `skopeo`, `jq`, `python3`, and required Python packages (`tenacity`, `GitPython`, `kubernetes`, `ruamel.yaml`)
 - `multi-arch-builder.py` installed at `/usr/local/bin/`
+
+The Tekton task references `quay.io/exd-guild-hello-operator/iib-build-task:latest`; rebuild and push the image when changing the builder script or bundled OPM versions.
 
 ## Contributing
 

--- a/task/iib-image-builder-oci-ta/README.md
+++ b/task/iib-image-builder-oci-ta/README.md
@@ -1,39 +1,93 @@
 # iib-image-builder-oci-ta task
 
-The iib-image-builder task builds source code into multi-architecture index images using Python orchestration with buildah. This task is specifically designed for building Operator Index Images that contain file-based catalogs.
+Tekton task that builds multi-architecture Operator Index Images from a Trusted Artifact using Python orchestration and buildah. It is designed for file-based catalogs (FBC) and follows the same build settings model as [IIB](https://github.com/release-engineering/iib).
 
-The task performs the following operations:
-- Generates OPM cache from file-based catalog (JSON or YAML files)
-- Builds container images for multiple architectures (amd64, arm64, ppc64le, s390x)
-- Creates and pushes multi-architecture manifest list
+## Overview
+
+The task runs two steps:
+
+1. **`use-trusted-artifact`** — extracts the application source from a Trusted Artifact URI into `/var/workdir/source`.
+2. **`build-multi-arch`** — runs `multi-arch-builder.py`, which:
+   - loads build settings from the IIB build metadata JSON file,
+   - generates an OPM cache from the file-based catalog under `configs/`,
+   - builds a per-architecture image with `buildah bud` for each target arch,
+   - assembles and pushes a multi-architecture manifest list with `buildah manifest`.
+
+Build settings `opm_version`, `labels`, `arches`, and `binary_image` are read **only** from the IIB build metadata file (default `.iib-build-metadata.json` in the build context). Override the path with the `IIB_BUILD_METADATA_FILE_PATH` parameter.
+
+Tekton parameters and environment variables (`IMAGE`, `COMMIT_SHA`, `CONTEXT`, `DOCKERFILE`, …) control where and how the build runs, not the index content itself.
+
+## Expected source layout
+
+The Trusted Artifact should contain at least:
+
+```
+.
+├── .iib-build-metadata.json   # IIB build settings (see below)
+├── configs/                   # file-based catalog (JSON or YAML)
+└── Dockerfile                 # index image Dockerfile (or path via DOCKERFILE param)
+```
+
+During the build, OPM writes a cache under `/var/workdir/cache`, then copies it into `<CONTEXT>/cache` so the Dockerfile can consume it.
+
+## IIB build metadata
+
+Place a JSON file in the build context (default: `.iib-build-metadata.json`). Relative paths in `IIB_BUILD_METADATA_FILE_PATH` are resolved against `CONTEXT`.
+
+| Field | Required | Description |
+|---|---|---|
+| `opm_version` | yes | OPM version for cache generation (e.g. `v1.48.0` or `opm-v1.48.0`) |
+| `arches` | yes | Target architectures, e.g. `["amd64", "arm64", "ppc64le", "s390x"]` |
+| `labels` | no | Object of label key/value pairs applied to built images |
+| `binary_image` | no | Passed to the Dockerfile as `BINARY_IMAGE` build arg |
+
+Example:
+
+```json
+{
+  "opm_version": "opm-v1.48.0",
+  "arches": ["amd64", "arm64"],
+  "labels": {
+    "com.redhat.index.delivery.version": "v4.19",
+    "com.redhat.index.delivery.distribution_scope": "prod"
+  },
+  "binary_image": "quay.io/operator-framework/upstream-registry-builder@sha256:7c8068817855b55e60ff5c2591c494130c2d105e0cc062836a5438a42935f8f8"
+}
+```
+
+Supported OPM versions are bundled in the task image: `v1.26.4`, `v1.40.0`, `v1.44.0`, and `v1.48.0`.
 
 ## Parameters
 
-|name|description|default value|required|
+| Name | Description | Default | Required |
 |---|---|---|---|
-|COMMIT_SHA|The image is built from this commit.|""|true|
-|CONTEXT|Path to the directory to use as context.|.|false|
-|DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
-|IMAGE|Reference of the image buildah will produce.||true|
-|LABELS|Additional key=value labels that should be applied to the image (comma-separated)|""|false|
-|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
-|STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
-|PLATFORMS|Comma-separated list of platforms to build for (e.g., amd64,arm64,ppc64le,s390x)|amd64,arm64,ppc64le,s390x|false|
-|OPM_VERSION|OPM version to use for cache generation|v1.40.0|false|
-|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
-|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+| `IMAGE` | Image reference buildah will push | — | yes |
+| `SOURCE_ARTIFACT` | Trusted Artifact URI with application source | — | yes |
+| `COMMIT_SHA` | Commit SHA; added as an extra manifest tag when set | `""` | yes at runtime* |
+| `CONTEXT` | Build context directory (relative to extracted source) | `.` | no |
+| `DOCKERFILE` | Path to the Dockerfile (relative to extracted source) | `./Dockerfile` | no |
+| `IIB_BUILD_METADATA_FILE_PATH` | Path to IIB build metadata JSON (relative to `CONTEXT` unless absolute) | `.iib-build-metadata.json` | no |
+| `STORAGE_DRIVER` | buildah storage driver | `overlay` | no |
+| `caTrustConfigMapName` | ConfigMap containing the CA bundle | `trusted-ca` | no |
+| `caTrustConfigMapKey` | Key in the ConfigMap with CA bundle data | `ca-bundle.crt` | no |
+
+\* `COMMIT_SHA` has an empty Tekton default but `multi-arch-builder.py` fails the build if it is not set.
 
 ## Results
 
-|name|description|
+| Name | Description |
 |---|---|
-|IMAGE_DIGEST|Digest of the multi-arch image manifest|
-|IMAGE_REF|Image reference of the built multi-arch image (includes digest)|
-|IMAGE_URL|Image repository and tag where the built image was pushed|
+| `IMAGE_DIGEST` | Digest of the pushed multi-arch manifest |
+| `IMAGE_REF` | Full image reference with digest (`name@sha256:…`) |
+| `IMAGE_URL` | Image repository and tag (`name:tag`) |
+
+## Resource requirements
+
+The task step template requests 4 CPU / 4 Gi memory and limits memory to 16 Gi. Multi-arch index builds with OPM cache generation are memory-intensive; adjust cluster quotas accordingly.
 
 ## Usage
 
-### Basic Usage
+### Basic TaskRun
 
 ```yaml
 apiVersion: tekton.dev/v1
@@ -52,7 +106,7 @@ spec:
       value: "oci://source-artifact"
 ```
 
-### Advanced Usage with Custom Parameters
+### Custom context, Dockerfile, and metadata path
 
 ```yaml
 apiVersion: tekton.dev/v1
@@ -69,21 +123,18 @@ spec:
       value: "abc123def456"
     - name: SOURCE_ARTIFACT
       value: "oci://source-artifact"
-    - name: PLATFORMS
-      value: "amd64,arm64"
-    - name: LABELS
-      value: "<label-name>=<label-value>, <label2-name>=<label2-value>"
-    - name: OPM_VERSION
-      value: "v1.40.0"
     - name: CONTEXT
       value: "./operator"
     - name: DOCKERFILE
-      value: "./operator/Dockerfile"
+      value: "./operator/index.Dockerfile"
+    - name: IIB_BUILD_METADATA_FILE_PATH
+      value: ".iib-build-metadata.json"
 ```
 
-## Related Documentation
+## Related documentation
 
 - [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/)
-- [File-based Catalogs](https://olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-a-catalog/#file-based-catalogs)
+- [File-based catalogs](https://olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-a-catalog/#file-based-catalogs)
 - [OPM (Operator Package Manager)](https://github.com/operator-framework/operator-registry)
 - [Buildah](https://buildah.io/)
+- [Repository README](../../README.md) — tests, container image build, and repository layout

--- a/task/iib-image-builder-oci-ta/iib-image-builder-oci-ta.yaml
+++ b/task/iib-image-builder-oci-ta/iib-image-builder-oci-ta.yaml
@@ -26,13 +26,13 @@ spec:
       description: Path to the Dockerfile to build.
       type: string
       default: ./Dockerfile
+    - name: IIB_BUILD_METADATA_FILE_PATH
+      description: Path to the IIB build metadata JSON file, relative to the build context unless absolute.
+      type: string
+      default: .iib-build-metadata.json
     - name: IMAGE
       description: Reference of the image buildah will produce.
       type: string
-    - name: LABELS
-      description: Additional key=value labels that should be applied to the image
-      type: string
-      default: ""
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with the application source code.
       type: string
@@ -40,14 +40,6 @@ spec:
       description: Storage driver to configure for buildah
       type: string
       default: overlay
-    - name: PLATFORMS
-      description: Comma-separated list of platforms to build for (e.g., amd64,arm64,ppc64le,s390x)
-      type: string
-      default: "amd64,arm64,ppc64le,s390x"
-    - name: OPM_VERSION
-      description: OPM version to use for cache generation
-      type: string
-      default: "v1.40.0"
     - name: caTrustConfigMapKey
       description: The name of the key in the ConfigMap that contains the CA bundle data.
       type: string
@@ -93,16 +85,12 @@ spec:
         value: $(params.CONTEXT)
       - name: DOCKERFILE
         value: $(params.DOCKERFILE)
+      - name: IIB_BUILD_METADATA_FILE_PATH
+        value: $(params.IIB_BUILD_METADATA_FILE_PATH)
       - name: IMAGE
         value: $(params.IMAGE)
-      - name: LABELS
-        value: $(params.LABELS)
       - name: STORAGE_DRIVER
         value: $(params.STORAGE_DRIVER)
-      - name: PLATFORMS
-        value: $(params.PLATFORMS)
-      - name: OPM_VERSION
-        value: $(params.OPM_VERSION)
       - name: CACHE_DIR
         value: /var/workdir/cache
     volumeMounts:
@@ -126,20 +114,21 @@ spec:
     - name: build-multi-arch
       image: quay.io/exd-guild-hello-operator/iib-build-task:latest
       workingDir: /var/workdir
+      env:
+        - name: IIB_BUILD_METADATA_FILE_PATH
+          value: $(params.IIB_BUILD_METADATA_FILE_PATH)
       script: |
         #!/bin/bash
         set -euo pipefail
 
-        echo "Labels: $LABELS"
-        echo "OPM Version: $OPM_VERSION"
-        echo "Platforms: $PLATFORMS"
-
         echo "[$(date --utc -Ins)] Starting multi-architecture build with Python orchestration"
+        echo "IIB build metadata file path: $(params.IIB_BUILD_METADATA_FILE_PATH)"
 
         # Run the Python build script
         python3 -u /usr/local/bin/multi-arch-builder.py \
           --ca-bundle /mnt/trusted-ca/ca-bundle.crt \
-          --output /var/workdir/build-results.json
+          --output /var/workdir/build-results.json \
+          --iib-build-metadata-file-path "$(params.IIB_BUILD_METADATA_FILE_PATH)"
 
         # Extract results for Tekton
         if [ -f "/var/workdir/build-results.json" ]; then

--- a/task/iib-image-builder-oci-ta/multi-arch-builder.py
+++ b/task/iib-image-builder-oci-ta/multi-arch-builder.py
@@ -25,6 +25,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+DEFAULT_IIB_BUILD_METADATA_FILE_PATH = '.iib-build-metadata.json'
+
 
 class IIBBaseException(Exception):
     """The base class for all IIB exceptions."""
@@ -132,6 +134,7 @@ class BuildConfig:
     cache_dir: str
     commit_sha: str
     opm_version: str
+    binary_image: str = ''
     # Architecture mapping for platform names to expected architecture values
     arch_map: Dict[str, str] = field(default_factory=lambda: {
         'amd64': 'amd64',
@@ -141,10 +144,157 @@ class BuildConfig:
     })
 
 
+def resolve_iib_build_metadata_path(context_path: str, metadata_file_path: str) -> Path:
+    """
+    Resolve the IIB build metadata file path.
+
+    Relative paths are resolved against the build context directory.
+
+    :param str context_path: build context directory
+    :param str metadata_file_path: path to the metadata file
+    :return: absolute path to the metadata file
+    :rtype: Path
+    """
+    path = Path(metadata_file_path)
+    if path.is_absolute():
+        return path
+    return Path(context_path) / path
+
+
+def load_iib_build_metadata(metadata_path: Path) -> Dict[str, Any]:
+    """
+    Load IIB build metadata from the configured metadata file.
+
+    :param Path metadata_path: path to the metadata JSON file
+    :return: parsed metadata as a dictionary
+    :rtype: Dict[str, Any]
+    :raises IIBError: if the file is missing or contains invalid JSON
+    """
+    if not metadata_path.is_file():
+        raise IIBError(
+            f'IIB build metadata file not found: {metadata_path}'
+        )
+
+    logger.info('Loading IIB build metadata from %s', metadata_path)
+    try:
+        with open(metadata_path, encoding='utf-8') as metadata_file:
+            metadata = json.load(metadata_file)
+    except json.JSONDecodeError as exc:
+        raise IIBError(f'Invalid JSON in {metadata_path}: {exc}') from exc
+
+    if not isinstance(metadata, dict):
+        raise IIBError(
+            f'IIB build metadata must be a JSON object, got {type(metadata).__name__}'
+        )
+
+    return metadata
+
+
+def opm_version_from_metadata(metadata: Dict[str, Any]) -> Optional[str]:
+    """
+    Extract ``opm_version`` from IIB build metadata.
+
+    Strips the ``opm-`` prefix when present (e.g. ``opm-v1.48.0`` -> ``v1.48.0``).
+
+    :param dict metadata: IIB build metadata
+    :return: normalized OPM version, or None if not set in metadata
+    :rtype: Optional[str]
+    """
+    raw_version = metadata.get('opm_version')
+    if raw_version is None:
+        return None
+
+    version = str(raw_version).strip()
+    if version.startswith('opm-'):
+        version = version[len('opm-'):]
+    return version
+
+
+def labels_from_metadata(metadata: Dict[str, Any]) -> Optional[List[str]]:
+    """
+    Extract ``labels`` from IIB build metadata.
+
+    :param dict metadata: IIB build metadata
+    :return: list of ``key=value`` labels, or None if not set in metadata
+    :rtype: Optional[List[str]]
+    :raises IIBError: if ``labels`` is present but not a JSON object
+    """
+    raw_labels = metadata.get('labels')
+    if raw_labels is None:
+        return None
+
+    if not isinstance(raw_labels, dict):
+        raise IIBError(
+            'Invalid labels in IIB build metadata file: '
+            f'expected object, got {type(raw_labels).__name__}'
+        )
+
+    return [f'{key}={value}' for key, value in raw_labels.items()]
+
+
+def arches_from_metadata(metadata: Dict[str, Any]) -> Optional[List[str]]:
+    """
+    Extract ``arches`` from IIB build metadata.
+
+    :param dict metadata: IIB build metadata
+    :return: list of platform/arch names, or None if not set in metadata
+    :rtype: Optional[List[str]]
+    :raises IIBError: if ``arches`` is present but invalid or empty
+    """
+    raw_arches = metadata.get('arches')
+    if raw_arches is None:
+        return None
+
+    if not isinstance(raw_arches, list):
+        raise IIBError(
+            'Invalid arches in IIB build metadata file: '
+            f'expected array, got {type(raw_arches).__name__}'
+        )
+
+    arches = [str(arch).strip() for arch in raw_arches if str(arch).strip()]
+    if not arches:
+        raise IIBError(
+            'Invalid arches in IIB build metadata file: '
+            'array must contain at least one architecture'
+        )
+
+    return arches
+
+
+def binary_image_from_metadata(metadata: Dict[str, Any]) -> Optional[str]:
+    """
+    Extract ``binary_image`` from IIB build metadata.
+
+    :param dict metadata: IIB build metadata
+    :return: container image reference for the index binary image, or None if not set
+    :rtype: Optional[str]
+    :raises IIBError: if ``binary_image`` is present but invalid or empty
+    """
+    raw_binary_image = metadata.get('binary_image')
+    if raw_binary_image is None:
+        return None
+
+    if not isinstance(raw_binary_image, str):
+        raise IIBError(
+            'Invalid binary_image in IIB build metadata file: '
+            f'expected string, got {type(raw_binary_image).__name__}'
+        )
+
+    binary_image = raw_binary_image.strip()
+    if not binary_image:
+        raise IIBError(
+            'Invalid binary_image in IIB build metadata file: '
+            'value must not be empty'
+        )
+
+    return binary_image
+
+
 def generate_cache_locally(
     base_dir: str,
     fbc_dir: str,
     local_cache_path: str,
+    opm_version: str,
 ) -> None:
     """
     Generate the cache for the index image locally before building it.
@@ -152,12 +302,12 @@ def generate_cache_locally(
     :param str base_dir: base directory where cache should be created.
     :param str fbc_dir: directory containing file-based catalog (JSON or YAML files).
     :param str local_cache_path: path to the locally generated cache.
+    :param str opm_version: OPM version used to select the ``opm`` binary (e.g. ``v1.48.0``).
     :return: Returns path to generated cache
     :rtype: str
     :raises: IIBError when cache was not generated
 
     """
-    opm_version = os.environ.get('OPM_VERSION', 'v1.40.0')
     opm_binary = f"/usr/bin/opm-{opm_version}"
 
     cmd = [
@@ -312,7 +462,9 @@ class MultiArchBuilder:
         # Add labels
         for label in self.config.labels:
             cmd.extend(['--label', label.strip()])
-        
+
+        if self.config.binary_image:
+            cmd.extend(['--build-arg', f'BINARY_IMAGE={self.config.binary_image}'])
 
         # Add context
         cmd.append(self.config.context_path)
@@ -464,7 +616,8 @@ class MultiArchBuilder:
         generate_cache_locally(
             base_dir=self.config.context_path,
             fbc_dir=str(catalog_dir),
-            local_cache_path=self.config.cache_dir
+            local_cache_path=self.config.cache_dir,
+            opm_version=self.config.opm_version,
         )
         
         # Copy cache into build context so Dockerfile can access it
@@ -504,20 +657,30 @@ class MultiArchBuilder:
         manifest_data = json.loads(result)
         digest = manifest_data.get('Digest', '')
         
-        return {
+        results: Dict[str, Any] = {
             'image_name': self.config.image_name,
             'digest': digest,
             'platforms': self.config.platforms,
             'platform_images': platform_images,
-            'opm_version': self.config.opm_version
+            'opm_version': self.config.opm_version,
         }
+        if self.config.binary_image:
+            results['binary_image'] = self.config.binary_image
+        return results
 
 
-def load_config_from_env() -> BuildConfig:
+def load_config_from_env(metadata_file_path: Optional[str] = None) -> BuildConfig:
     """
-    Load configuration from environment variables.
+    Load configuration from IIB build metadata and Tekton environment variables.
 
-    :return: BuildConfig object populated from environment variables
+    Values defined in the IIB build metadata file (``opm_version``, ``labels``,
+    ``arches``, ``binary_image``) are read only from that file. The file path is
+    set via ``--iib-build-metadata-file-path`` or the ``IIB_BUILD_METADATA_FILE_PATH``
+    environment variable. Environment variables are used for Tekton/task settings
+    (``IMAGE``, ``COMMIT_SHA``, etc.).
+
+    :param Optional[str] metadata_file_path: path to the metadata file (overrides env)
+    :return: BuildConfig object populated from metadata and environment variables
     :rtype: BuildConfig
     """
     # Source code is extracted to /var/workdir/source by the use-trusted-artifact step
@@ -532,16 +695,69 @@ def load_config_from_env() -> BuildConfig:
     dockerfile_path = os.environ.get('DOCKERFILE', './Dockerfile')
     if not dockerfile_path.startswith('/'):
         dockerfile_path = os.path.join(source_dir, dockerfile_path)
-    
+
+    if metadata_file_path is None:
+        metadata_file_path = (
+            os.environ.get('IIB_BUILD_METADATA_FILE_PATH')
+            or DEFAULT_IIB_BUILD_METADATA_FILE_PATH
+        )
+    metadata_file_path = metadata_file_path.strip() or DEFAULT_IIB_BUILD_METADATA_FILE_PATH
+    logger.info('IIB build metadata file path: %s', metadata_file_path)
+
+    metadata_path = resolve_iib_build_metadata_path(context_path, metadata_file_path)
+    metadata = load_iib_build_metadata(metadata_path)
+
+    opm_version = opm_version_from_metadata(metadata)
+    if opm_version is None:
+        raise IIBError(
+            f'opm_version is required in {metadata_path}'
+        )
+    logger.info(
+        'OPM version %s loaded from %s',
+        opm_version,
+        metadata_path,
+    )
+
+    labels = labels_from_metadata(metadata)
+    if labels is None:
+        labels = []
+    logger.info(
+        'Loaded %d label(s) from %s',
+        len(labels),
+        metadata_path,
+    )
+
+    platforms = arches_from_metadata(metadata)
+    if platforms is None:
+        raise IIBError(
+            f'arches is required in {metadata_path}'
+        )
+    logger.info(
+        'Platforms %s loaded from %s (arches)',
+        ', '.join(platforms),
+        metadata_path,
+    )
+
+    binary_image = binary_image_from_metadata(metadata) or ''
+    if binary_image:
+        logger.info(
+            'Binary image %s loaded from %s',
+            binary_image,
+            metadata_path,
+        )
+    else:
+        logger.info('No binary_image configured in %s', metadata_path)
+
     return BuildConfig(
         image_name=os.environ.get('IMAGE', ''),
         dockerfile_path=dockerfile_path,
         context_path=context_path,
-        platforms=os.environ.get('PLATFORMS', 'amd64,arm64,ppc64le,s390x').split(','),
-        labels=os.environ.get('LABELS', '').split(','),
+        platforms=platforms,
+        labels=labels,
         cache_dir=os.environ.get('CACHE_DIR', '/var/workdir/cache'),
         commit_sha=os.environ.get('COMMIT_SHA', ''),
-        opm_version=os.environ.get('OPM_VERSION', 'v1.40.0'),
+        opm_version=opm_version,
+        binary_image=binary_image,
     )
 
 
@@ -555,12 +771,22 @@ def main():
     parser = argparse.ArgumentParser(description='Multi-architecture container builder')
     parser.add_argument('--ca-bundle', help='Path to CA bundle file')
     parser.add_argument('--output', help='Path to output results JSON file')
-    
+    parser.add_argument(
+        '--iib-build-metadata-file-path',
+        default=os.environ.get(
+            'IIB_BUILD_METADATA_FILE_PATH',
+            DEFAULT_IIB_BUILD_METADATA_FILE_PATH,
+        ),
+        help=(
+            'Path to IIB build metadata JSON file '
+            '(relative to CONTEXT unless absolute; default: .iib-build-metadata.json)'
+        ),
+    )
+
     args = parser.parse_args()
-    
+
     try:
-        # Load configuration from environment
-        config = load_config_from_env()
+        config = load_config_from_env(metadata_file_path=args.iib_build_metadata_file_path)
         
         # Validate required fields
         if not config.image_name or not config.commit_sha:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,3 +65,43 @@ def builder(build_config):
     import multi_arch_builder as mab
 
     return mab.MultiArchBuilder(build_config)
+
+
+@pytest.fixture()
+def sample_iib_metadata():
+    """Sample IIB build metadata as used in PRs."""
+    return {
+        "opm_version": "opm-v1.48.0",
+        "labels": {
+            "com.redhat.index.delivery.version": "v4.19",
+            "com.redhat.index.delivery.distribution_scope": "prod",
+        },
+        "binary_image": (
+            "quay.io/operator-framework/upstream-registry-builder"
+            "@sha256:7c8068817855b55e60ff5c2591c494130c2d105e0cc062836a5438a42935f8f8"
+        ),
+        "request_id": 89240,
+        "arches": ["amd64"],
+    }
+
+
+@pytest.fixture()
+def metadata_build_context(tmp_path, sample_iib_metadata, monkeypatch):
+    """
+    Build context with ``.iib-build-metadata.json`` and Tekton env vars set.
+    """
+    import json
+
+    context = tmp_path / "index-build"
+    context.mkdir()
+    (context / ".iib-build-metadata.json").write_text(
+        json.dumps(sample_iib_metadata), encoding="utf-8"
+    )
+
+    monkeypatch.setenv("IMAGE", "quay.io/org/index:v1.0")
+    monkeypatch.setenv("COMMIT_SHA", "abc123def456")
+    monkeypatch.setenv("CONTEXT", str(context))
+    monkeypatch.setenv("DOCKERFILE", str(context / "index.Dockerfile"))
+    monkeypatch.delenv("IIB_BUILD_METADATA_FILE_PATH", raising=False)
+
+    return context

--- a/tests/tekton/test_iib_image_builder_task.py
+++ b/tests/tekton/test_iib_image_builder_task.py
@@ -91,10 +91,8 @@ OPTIONAL_PARAMS_WITH_DEFAULTS = {
     "COMMIT_SHA": "",
     "CONTEXT": ".",
     "DOCKERFILE": "./Dockerfile",
-    "LABELS": "",
+    "IIB_BUILD_METADATA_FILE_PATH": ".iib-build-metadata.json",
     "STORAGE_DRIVER": "overlay",
-    "PLATFORMS": "amd64,arm64,ppc64le,s390x",
-    "OPM_VERSION": "v1.40.0",
     "caTrustConfigMapKey": "ca-bundle.crt",
     "caTrustConfigMapName": "trusted-ca",
 }
@@ -126,10 +124,11 @@ class TestTaskParameters:
         for name, param in params_by_name.items():
             assert param.get("description"), f"Param '{name}' is missing 'description'"
 
-    def test_platforms_default_covers_all_arches(self, params_by_name):
-        default = params_by_name["PLATFORMS"]["default"]
-        for arch in ("amd64", "arm64", "ppc64le", "s390x"):
-            assert arch in default, f"Architecture '{arch}' missing from PLATFORMS default"
+    def test_iib_build_metadata_file_path_default(self, params_by_name):
+        assert (
+            params_by_name["IIB_BUILD_METADATA_FILE_PATH"]["default"]
+            == ".iib-build-metadata.json"
+        )
 
     def test_image_param_is_string_type(self, params_by_name):
         assert params_by_name["IMAGE"]["type"] == "string"
@@ -218,7 +217,12 @@ class TestStepTemplate:
     def test_step_template_propagates_required_env_vars(self, spec):
         step_template = spec.get("stepTemplate", {})
         env_names = {e["name"] for e in step_template.get("env", [])}
-        for required in ("IMAGE", "COMMIT_SHA", "PLATFORMS", "OPM_VERSION", "CACHE_DIR"):
+        for required in (
+            "IMAGE",
+            "COMMIT_SHA",
+            "IIB_BUILD_METADATA_FILE_PATH",
+            "CACHE_DIR",
+        ):
             assert required in env_names, f"stepTemplate must expose env var '{required}'"
 
     def test_step_template_mounts_shared_and_workdir_volumes(self, spec):
@@ -288,6 +292,16 @@ class TestTaskSteps:
     def test_build_step_script_uses_set_euo_pipefail(self, steps_by_name):
         script = steps_by_name["build-multi-arch"].get("script", "")
         assert "set -euo pipefail" in script
+
+    def test_build_step_passes_metadata_file_path_to_python(self, steps_by_name):
+        script = steps_by_name["build-multi-arch"].get("script", "")
+        assert "--iib-build-metadata-file-path" in script
+        assert "IIB_BUILD_METADATA_FILE_PATH" in script
+
+    def test_build_step_sets_metadata_file_path_env(self, steps_by_name):
+        step = steps_by_name["build-multi-arch"]
+        env_names = {e["name"] for e in step.get("env", [])}
+        assert "IIB_BUILD_METADATA_FILE_PATH" in env_names
 
     def test_trusted_artifact_step_has_image(self, steps_by_name):
         assert steps_by_name["use-trusted-artifact"].get("image"), (

--- a/tests/unit/test_multi_arch_builder.py
+++ b/tests/unit/test_multi_arch_builder.py
@@ -6,6 +6,7 @@ filename contains a hyphen) and registered in sys.modules as
 ``multi_arch_builder``.
 """
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch, call
@@ -180,12 +181,12 @@ class TestGenerateCacheLocally:
 
         mock_run_cmd.side_effect = side_effect
 
-        with patch.dict("os.environ", {"OPM_VERSION": "v1.40.0"}):
-            mab.generate_cache_locally(
-                base_dir=str(tmp_path),
-                fbc_dir=str(fbc_dir),
-                local_cache_path=str(cache_dir),
-            )
+        mab.generate_cache_locally(
+            base_dir=str(tmp_path),
+            fbc_dir=str(fbc_dir),
+            local_cache_path=str(cache_dir),
+            opm_version="v1.40.0",
+        )
 
         mock_run_cmd.assert_called_once()
         cmd_arg = mock_run_cmd.call_args[0][0]
@@ -213,6 +214,7 @@ class TestGenerateCacheLocally:
             base_dir=str(tmp_path),
             fbc_dir=str(tmp_path / "fbc"),
             local_cache_path=str(cache_dir),
+            opm_version="v1.40.0",
         )
 
         assert not stale_file.exists()
@@ -232,6 +234,7 @@ class TestGenerateCacheLocally:
                 base_dir=str(tmp_path),
                 fbc_dir=str(tmp_path / "fbc"),
                 local_cache_path=str(cache_dir),
+                opm_version="v1.40.0",
             )
 
     @patch("multi_arch_builder.run_cmd")
@@ -245,10 +248,11 @@ class TestGenerateCacheLocally:
                 base_dir=str(tmp_path),
                 fbc_dir=str(tmp_path / "fbc"),
                 local_cache_path=non_existent,
+                opm_version="v1.40.0",
             )
 
     @patch("multi_arch_builder.run_cmd")
-    def test_uses_opm_version_from_environment(self, mock_run_cmd, tmp_path):
+    def test_uses_opm_version_argument(self, mock_run_cmd, tmp_path):
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
 
@@ -257,12 +261,12 @@ class TestGenerateCacheLocally:
 
         mock_run_cmd.side_effect = side_effect
 
-        with patch.dict("os.environ", {"OPM_VERSION": "v1.99.0"}):
-            mab.generate_cache_locally(
-                base_dir=str(tmp_path),
-                fbc_dir=str(tmp_path / "fbc"),
-                local_cache_path=str(cache_dir),
-            )
+        mab.generate_cache_locally(
+            base_dir=str(tmp_path),
+            fbc_dir=str(tmp_path / "fbc"),
+            local_cache_path=str(cache_dir),
+            opm_version="v1.99.0",
+        )
 
         cmd_arg = mock_run_cmd.call_args[0][0]
         assert cmd_arg[0] == "/usr/bin/opm-v1.99.0"
@@ -439,6 +443,23 @@ class TestBuildImage:
         assert cmd[-1] == "/tmp/ctx"
 
     @patch("multi_arch_builder.MultiArchBuilder._verify_image_architecture")
+    @patch("multi_arch_builder.run_cmd")
+    def test_adds_binary_image_build_arg(self, mock_run_cmd, mock_verify, builder):
+        builder.config.binary_image = "quay.io/binary@sha256:abc"
+        builder._build_image("amd64", "quay.io/org/img:latest-amd64")
+        cmd = mock_run_cmd.call_args[0][0]
+        assert "--build-arg" in cmd
+        assert "BINARY_IMAGE=quay.io/binary@sha256:abc" in cmd
+
+    @patch("multi_arch_builder.MultiArchBuilder._verify_image_architecture")
+    @patch("multi_arch_builder.run_cmd")
+    def test_omits_binary_image_build_arg_when_unset(self, mock_run_cmd, mock_verify, builder):
+        builder.config.binary_image = ""
+        builder._build_image("amd64", "quay.io/org/img:latest-amd64")
+        cmd = mock_run_cmd.call_args[0][0]
+        assert "BINARY_IMAGE=" not in cmd
+
+    @patch("multi_arch_builder.MultiArchBuilder._verify_image_architecture")
     @patch("multi_arch_builder.run_cmd", side_effect=mab.ExternalServiceError("503"))
     def test_raises_external_service_error_on_network_failure(
         self, mock_run_cmd, mock_verify, builder
@@ -532,61 +553,218 @@ class TestCreateAndPushManifestList:
 
 
 # ---------------------------------------------------------------------------
+# IIB build metadata helpers
+# ---------------------------------------------------------------------------
+
+
+class TestResolveIibBuildMetadataPath:
+    def test_relative_path_is_resolved_against_context(self, tmp_path):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        resolved = mab.resolve_iib_build_metadata_path(str(context), ".iib-build-metadata.json")
+        assert resolved == context / ".iib-build-metadata.json"
+
+    def test_absolute_path_is_unchanged(self, tmp_path):
+        absolute = tmp_path / "custom" / "metadata.json"
+        absolute.parent.mkdir()
+        resolved = mab.resolve_iib_build_metadata_path(str(tmp_path / "ctx"), str(absolute))
+        assert resolved == absolute
+
+
+class TestLoadIibBuildMetadata:
+    def test_loads_valid_json(self, tmp_path):
+        metadata_file = tmp_path / ".iib-build-metadata.json"
+        metadata_file.write_text('{"opm_version": "v1.48.0"}', encoding="utf-8")
+        assert mab.load_iib_build_metadata(metadata_file) == {"opm_version": "v1.48.0"}
+
+    def test_raises_when_file_missing(self, tmp_path):
+        with pytest.raises(mab.IIBError, match="not found"):
+            mab.load_iib_build_metadata(tmp_path / "missing.json")
+
+    def test_raises_on_invalid_json(self, tmp_path):
+        metadata_file = tmp_path / ".iib-build-metadata.json"
+        metadata_file.write_text("{not json", encoding="utf-8")
+        with pytest.raises(mab.IIBError, match="Invalid JSON"):
+            mab.load_iib_build_metadata(metadata_file)
+
+    def test_raises_when_root_is_not_object(self, tmp_path):
+        metadata_file = tmp_path / ".iib-build-metadata.json"
+        metadata_file.write_text('["array"]', encoding="utf-8")
+        with pytest.raises(mab.IIBError, match="must be a JSON object"):
+            mab.load_iib_build_metadata(metadata_file)
+
+
+class TestOpmVersionFromMetadata:
+    def test_strips_opm_prefix(self):
+        assert mab.opm_version_from_metadata({"opm_version": "opm-v1.48.0"}) == "v1.48.0"
+
+    def test_returns_version_without_prefix(self):
+        assert mab.opm_version_from_metadata({"opm_version": "v1.40.0"}) == "v1.40.0"
+
+    def test_returns_none_when_missing(self):
+        assert mab.opm_version_from_metadata({}) is None
+
+
+class TestLabelsFromMetadata:
+    def test_converts_dict_to_key_value_list(self, sample_iib_metadata):
+        labels = mab.labels_from_metadata(sample_iib_metadata)
+        assert labels == [
+            "com.redhat.index.delivery.version=v4.19",
+            "com.redhat.index.delivery.distribution_scope=prod",
+        ]
+
+    def test_returns_none_when_missing(self):
+        assert mab.labels_from_metadata({}) is None
+
+    def test_raises_when_labels_not_object(self):
+        with pytest.raises(mab.IIBError, match="Invalid labels"):
+            mab.labels_from_metadata({"labels": "bad"})
+
+
+class TestArchesFromMetadata:
+    def test_returns_arch_list(self, sample_iib_metadata):
+        assert mab.arches_from_metadata(sample_iib_metadata) == ["amd64"]
+
+    def test_returns_none_when_missing(self):
+        assert mab.arches_from_metadata({}) is None
+
+    def test_raises_when_arches_not_array(self):
+        with pytest.raises(mab.IIBError, match="Invalid arches"):
+            mab.arches_from_metadata({"arches": "amd64"})
+
+    def test_raises_when_arches_empty(self):
+        with pytest.raises(mab.IIBError, match="at least one architecture"):
+            mab.arches_from_metadata({"arches": []})
+
+
+class TestBinaryImageFromMetadata:
+    def test_returns_image_reference(self, sample_iib_metadata):
+        image = mab.binary_image_from_metadata(sample_iib_metadata)
+        assert image.startswith("quay.io/operator-framework/")
+
+    def test_returns_none_when_missing(self):
+        assert mab.binary_image_from_metadata({}) is None
+
+    def test_raises_when_not_string(self):
+        with pytest.raises(mab.IIBError, match="Invalid binary_image"):
+            mab.binary_image_from_metadata({"binary_image": 123})
+
+    def test_raises_when_empty_string(self):
+        with pytest.raises(mab.IIBError, match="must not be empty"):
+            mab.binary_image_from_metadata({"binary_image": "   "})
+
+
+# ---------------------------------------------------------------------------
 # load_config_from_env
 # ---------------------------------------------------------------------------
 
 
 class TestLoadConfigFromEnv:
-    def _load(self, monkeypatch, overrides=None):
-        defaults = {"IMAGE": "quay.io/org/img:latest", "COMMIT_SHA": "sha123"}
-        env = {**defaults, **(overrides or {})}
-        for k, v in env.items():
-            if v is None:
-                monkeypatch.delenv(k, raising=False)
-            else:
-                monkeypatch.setenv(k, v)
-        return mab.load_config_from_env()
+    def test_loads_values_from_metadata_file(self, metadata_build_context):
+        cfg = mab.load_config_from_env()
+        assert cfg.image_name == "quay.io/org/index:v1.0"
+        assert cfg.commit_sha == "abc123def456"
+        assert cfg.opm_version == "v1.48.0"
+        assert cfg.platforms == ["amd64"]
+        assert cfg.labels == [
+            "com.redhat.index.delivery.version=v4.19",
+            "com.redhat.index.delivery.distribution_scope=prod",
+        ]
+        assert cfg.binary_image.startswith("quay.io/operator-framework/")
 
-    def test_loads_image_and_commit_sha(self, monkeypatch):
-        cfg = self._load(monkeypatch)
-        assert cfg.image_name == "quay.io/org/img:latest"
-        assert cfg.commit_sha == "sha123"
+    def test_custom_metadata_file_path(self, metadata_build_context, sample_iib_metadata):
+        custom = metadata_build_context / "meta" / "build.json"
+        custom.parent.mkdir()
+        custom.write_text(json.dumps(sample_iib_metadata), encoding="utf-8")
+        cfg = mab.load_config_from_env(metadata_file_path="meta/build.json")
+        assert cfg.opm_version == "v1.48.0"
 
-    def test_default_platforms(self, monkeypatch):
-        cfg = self._load(monkeypatch, {"PLATFORMS": None})
-        assert cfg.platforms == ["amd64", "arm64", "ppc64le", "s390x"]
+    def test_metadata_file_path_from_env(self, metadata_build_context, monkeypatch):
+        monkeypatch.setenv(
+            "IIB_BUILD_METADATA_FILE_PATH",
+            ".iib-build-metadata.json",
+        )
+        cfg = mab.load_config_from_env()
+        assert cfg.opm_version == "v1.48.0"
 
-    def test_custom_platforms(self, monkeypatch):
-        cfg = self._load(monkeypatch, {"PLATFORMS": "amd64,arm64"})
-        assert cfg.platforms == ["amd64", "arm64"]
+    def test_relative_context_is_joined_with_source_dir(self, tmp_path, monkeypatch):
+        source = tmp_path / "source"
+        ctx = source / "myapp"
+        ctx.mkdir(parents=True)
+        (ctx / ".iib-build-metadata.json").write_text(
+            json.dumps({"opm_version": "v1.40.0", "arches": ["amd64"]}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("IMAGE", "quay.io/org/img:latest")
+        monkeypatch.setenv("COMMIT_SHA", "sha123")
+        monkeypatch.setenv("CONTEXT", "myapp")
+        monkeypatch.setenv("DOCKERFILE", "./Dockerfile")
 
-    def test_relative_context_is_joined_with_source_dir(self, monkeypatch):
-        cfg = self._load(monkeypatch, {"CONTEXT": "myapp"})
-        assert cfg.context_path == "/var/workdir/source/myapp"
+        real_join = os.path.join
 
-    def test_absolute_context_is_used_as_is(self, monkeypatch):
-        cfg = self._load(monkeypatch, {"CONTEXT": "/absolute/path"})
-        assert cfg.context_path == "/absolute/path"
+        def join_under_tekton_source(first, *rest):
+            if first == "/var/workdir/source" and rest:
+                return str(source / rest[0].lstrip("./"))
+            return real_join(first, *rest)
 
-    def test_relative_dockerfile_is_joined_with_source_dir(self, monkeypatch):
-        cfg = self._load(monkeypatch, {"DOCKERFILE": "./Dockerfile"})
-        assert cfg.dockerfile_path == "/var/workdir/source/./Dockerfile"
+        monkeypatch.setattr(os.path, "join", join_under_tekton_source)
 
-    def test_absolute_dockerfile_is_used_as_is(self, monkeypatch):
-        cfg = self._load(monkeypatch, {"DOCKERFILE": "/abs/Dockerfile"})
-        assert cfg.dockerfile_path == "/abs/Dockerfile"
+        cfg = mab.load_config_from_env()
+        assert cfg.context_path == str(source / "myapp")
 
-    def test_default_opm_version(self, monkeypatch):
-        cfg = self._load(monkeypatch, {"OPM_VERSION": None})
-        assert cfg.opm_version == "v1.40.0"
+    def test_absolute_context_is_used_as_is(self, metadata_build_context, monkeypatch):
+        monkeypatch.setenv("CONTEXT", str(metadata_build_context))
+        cfg = mab.load_config_from_env()
+        assert cfg.context_path == str(metadata_build_context)
 
-    def test_default_cache_dir(self, monkeypatch):
-        cfg = self._load(monkeypatch, {"CACHE_DIR": None})
+    def test_relative_dockerfile_is_joined_with_source_dir(self, monkeypatch, tmp_path):
+        source = tmp_path / "source"
+        ctx = source / "app"
+        ctx.mkdir(parents=True)
+        (ctx / ".iib-build-metadata.json").write_text(
+            json.dumps({"opm_version": "v1.40.0", "arches": ["amd64"]}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("IMAGE", "quay.io/org/img:latest")
+        monkeypatch.setenv("COMMIT_SHA", "sha123")
+        monkeypatch.setenv("CONTEXT", str(ctx))
+        monkeypatch.setenv("DOCKERFILE", "./index.Dockerfile")
+
+        cfg = mab.load_config_from_env()
+        assert cfg.dockerfile_path == "/var/workdir/source/./index.Dockerfile"
+
+    def test_default_cache_dir(self, metadata_build_context, monkeypatch):
+        monkeypatch.delenv("CACHE_DIR", raising=False)
+        cfg = mab.load_config_from_env()
         assert cfg.cache_dir == "/var/workdir/cache"
 
-    def test_empty_labels_produce_single_empty_string(self, monkeypatch):
-        cfg = self._load(monkeypatch, {"LABELS": None})
-        assert cfg.labels == [""]
+    def test_raises_when_opm_version_missing(self, tmp_path, monkeypatch):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        (context / ".iib-build-metadata.json").write_text(
+            json.dumps({"arches": ["amd64"]}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("IMAGE", "quay.io/org/img:latest")
+        monkeypatch.setenv("COMMIT_SHA", "sha123")
+        monkeypatch.setenv("CONTEXT", str(context))
+
+        with pytest.raises(mab.IIBError, match="opm_version is required"):
+            mab.load_config_from_env()
+
+    def test_raises_when_arches_missing(self, tmp_path, monkeypatch):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        (context / ".iib-build-metadata.json").write_text(
+            json.dumps({"opm_version": "v1.40.0"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("IMAGE", "quay.io/org/img:latest")
+        monkeypatch.setenv("COMMIT_SHA", "sha123")
+        monkeypatch.setenv("CONTEXT", str(context))
+
+        with pytest.raises(mab.IIBError, match="arches is required"):
+            mab.load_config_from_env()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Load build settings from IIB build metadata file
Read opm_version, arches, labels, and binary_image from .iib-build-metadata.json instead of Tekton params. Add IIB_BUILD_METADATA_FILE_PATH parameter and remove PLATFORMS, OPM_VERSION, and LABELS.

Signed-off-by: Jan Lipovský <jlipovsk@redhat.com>
Assisted-by: Cursor

[CLOUDDST-32654]