### PR TITLE
Fix loading of opm version from metadata

### DIFF
--- a/task/iib-image-builder-oci-ta/README.md
+++ b/task/iib-image-builder-oci-ta/README.md
@@ -36,7 +36,7 @@ Place a JSON file in the build context (default: `.iib-build-metadata.json`). Re
 
 | Field | Required | Description |
 |---|---|---|
-| `opm_version` | yes | OPM version for cache generation (e.g. `v1.48.0` or `opm-v1.48.0`) |
+| `opm_version` | yes | OPM version for cache generation. Accepts `v1.48.0`, `opm-v1.48.0`, or IIB's default `opm` (see [opm_version normalization](#opm_version-normalization) below). Must not be empty. |
 | `arches` | yes | Target architectures, e.g. `["amd64", "arm64", "ppc64le", "s390x"]` |
 | `labels` | no | Object of label key/value pairs applied to built images |
 | `binary_image` | no | Passed to the Dockerfile as `BINARY_IMAGE` build arg |
@@ -56,6 +56,20 @@ Example:
 ```
 
 Supported OPM versions are bundled in the task image: `v1.26.4`, `v1.40.0`, `v1.44.0`, and `v1.48.0`.
+
+### opm_version normalization
+
+The builder resolves `opm_version` from metadata as follows:
+
+| Metadata value | Result |
+|---|---|
+| Key missing | Build fails: `opm_version is required` |
+| `""` or whitespace only | Build fails: `value must not be empty` |
+| `"opm"` (IIB `iib_default_opm`) | Uses latest bundled version (`v1.48.0`) with a warning in the log |
+| `"opm-v1.48.0"` | Strips the `opm-` prefix → `v1.48.0` |
+| `"v1.48.0"` | Used as-is |
+
+IIB often writes `"opm"` when no OCP-to-OPM mapping is configured. The task image has no unversioned `opm` binary in `PATH`; only versioned binaries under `/usr/bin/opm-<version>` are available. Prefer an explicit version in metadata when you know which OPM release the index requires.
 
 ## Parameters
 

--- a/task/iib-image-builder-oci-ta/multi-arch-builder.py
+++ b/task/iib-image-builder-oci-ta/multi-arch-builder.py
@@ -31,9 +31,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-DEFAULT_IIB_BUILD_METADATA_FILE_PATH = '.iib-build-metadata.json'
+DEFAULT_IIB_BUILD_METADATA_FILE_PATH = ".iib-build-metadata.json"
 # OPM binaries bundled in Containerfile.iib-build-task (keep in sync).
-BUNDLED_OPM_VERSIONS = ('v1.26.4', 'v1.40.0', 'v1.44.0', 'v1.48.0')
+BUNDLED_OPM_VERSIONS = ("v1.26.4", "v1.40.0", "v1.44.0", "v1.48.0")
 DEFAULT_OPM_VERSION = BUNDLED_OPM_VERSIONS[-1]
 
 
@@ -218,24 +218,21 @@ def opm_version_from_metadata(metadata: Dict[str, Any]) -> Optional[str]:
 
     version = str(raw_version).strip()
     if not version:
-        raise IIBError(
-            'Invalid opm_version in IIB build metadata file: '
-            'value must not be empty'
-        )
+        raise IIBError("Invalid opm_version in IIB build metadata file: value must not be empty")
 
-    if version.startswith('opm-'):
-        version = version.removeprefix('opm-')
+    if version.startswith("opm-"):
+        version = version.removeprefix("opm-")
 
     if not version:
         raise IIBError(
-            'Invalid opm_version in IIB build metadata file: '
-            f'no version after stripping opm- prefix from {raw_version!r}'
+            "Invalid opm_version in IIB build metadata file: "
+            f"no version after stripping opm- prefix from {raw_version!r}"
         )
 
     # IIB may write the default command name without a version suffix.
-    if version == 'opm':
+    if version == "opm":
         logger.warning(
-            'opm_version in metadata is %r (IIB default); using bundled OPM %s',
+            "opm_version in metadata is %r (IIB default); using bundled OPM %s",
             raw_version,
             DEFAULT_OPM_VERSION,
         )
@@ -253,15 +250,15 @@ def resolve_opm_binary_path(opm_version: str) -> str:
     :rtype: str
     :raises IIBError: if the requested version is not bundled in the task image
     """
-    opm_binary = Path(f'/usr/bin/opm-{opm_version}')
+    opm_binary = Path(f"/usr/bin/opm-{opm_version}")
     if opm_binary.is_file():
         return str(opm_binary)
 
-    supported = ', '.join(BUNDLED_OPM_VERSIONS)
+    supported = ", ".join(BUNDLED_OPM_VERSIONS)
     raise IIBError(
-        f'OPM binary not found at {opm_binary}. '
-        f'Supported opm_version values: {supported} or opm-<version> '
-        f'(e.g. opm-v1.48.0). Got opm_version={opm_version!r}.'
+        f"OPM binary not found at {opm_binary}. "
+        f"Supported opm_version values: {supported} or opm-<version> "
+        f"(e.g. opm-v1.48.0). Got opm_version={opm_version!r}."
     )
 
 
@@ -764,14 +761,12 @@ def load_config_from_env(metadata_file_path: Optional[str] = None) -> BuildConfi
     metadata_path = resolve_iib_build_metadata_path(context_path, metadata_file_path)
     metadata = load_iib_build_metadata(metadata_path)
 
-    raw_opm_version = metadata.get('opm_version')
+    raw_opm_version = metadata.get("opm_version")
     opm_version = opm_version_from_metadata(metadata)
     if opm_version is None:
-        raise IIBError(
-            f'opm_version is required in {metadata_path}'
-        )
+        raise IIBError(f"opm_version is required in {metadata_path}")
     logger.info(
-        'OPM version %s loaded from %s (raw: %r)',
+        "OPM version %s loaded from %s (raw: %r)",
         opm_version,
         metadata_path,
         raw_opm_version,

--- a/task/iib-image-builder-oci-ta/multi-arch-builder.py
+++ b/task/iib-image-builder-oci-ta/multi-arch-builder.py
@@ -31,7 +31,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-DEFAULT_IIB_BUILD_METADATA_FILE_PATH = ".iib-build-metadata.json"
+DEFAULT_IIB_BUILD_METADATA_FILE_PATH = '.iib-build-metadata.json'
+# OPM binaries bundled in Containerfile.iib-build-task (keep in sync).
+BUNDLED_OPM_VERSIONS = ('v1.26.4', 'v1.40.0', 'v1.44.0', 'v1.48.0')
+DEFAULT_OPM_VERSION = BUNDLED_OPM_VERSIONS[-1]
 
 
 class IIBBaseException(Exception):
@@ -200,19 +203,66 @@ def opm_version_from_metadata(metadata: Dict[str, Any]) -> Optional[str]:
     Extract ``opm_version`` from IIB build metadata.
 
     Strips the ``opm-`` prefix when present (e.g. ``opm-v1.48.0`` -> ``v1.48.0``).
+    The bare value ``opm`` (IIB's ``iib_default_opm``) is mapped to the latest
+    bundled OPM version in the task image. A missing key returns ``None``; an
+    empty or whitespace-only value raises ``IIBError``.
 
     :param dict metadata: IIB build metadata
     :return: normalized OPM version, or None if not set in metadata
     :rtype: Optional[str]
+    :raises IIBError: if ``opm_version`` is present but empty or malformed
     """
     raw_version = metadata.get("opm_version")
     if raw_version is None:
         return None
 
     version = str(raw_version).strip()
-    if version.startswith("opm-"):
-        version = version.removeprefix("opm-")
+    if not version:
+        raise IIBError(
+            'Invalid opm_version in IIB build metadata file: '
+            'value must not be empty'
+        )
+
+    if version.startswith('opm-'):
+        version = version.removeprefix('opm-')
+
+    if not version:
+        raise IIBError(
+            'Invalid opm_version in IIB build metadata file: '
+            f'no version after stripping opm- prefix from {raw_version!r}'
+        )
+
+    # IIB may write the default command name without a version suffix.
+    if version == 'opm':
+        logger.warning(
+            'opm_version in metadata is %r (IIB default); using bundled OPM %s',
+            raw_version,
+            DEFAULT_OPM_VERSION,
+        )
+        return DEFAULT_OPM_VERSION
+
     return version
+
+
+def resolve_opm_binary_path(opm_version: str) -> str:
+    """
+    Resolve the filesystem path to the versioned ``opm`` binary.
+
+    :param str opm_version: normalized OPM version (e.g. ``v1.48.0``)
+    :return: absolute path to the ``opm`` binary
+    :rtype: str
+    :raises IIBError: if the requested version is not bundled in the task image
+    """
+    opm_binary = Path(f'/usr/bin/opm-{opm_version}')
+    if opm_binary.is_file():
+        return str(opm_binary)
+
+    supported = ', '.join(BUNDLED_OPM_VERSIONS)
+    raise IIBError(
+        f'OPM binary not found at {opm_binary}. '
+        f'Supported opm_version values: {supported} or opm-<version> '
+        f'(e.g. opm-v1.48.0). Got opm_version={opm_version!r}.'
+    )
 
 
 def labels_from_metadata(metadata: Dict[str, Any]) -> Optional[List[str]]:
@@ -310,7 +360,7 @@ def generate_cache_locally(
     :raises: IIBError when cache was not generated
 
     """
-    opm_binary = f"/usr/bin/opm-{opm_version}"
+    opm_binary = resolve_opm_binary_path(opm_version)
 
     cmd = [
         opm_binary,
@@ -714,10 +764,18 @@ def load_config_from_env(metadata_file_path: Optional[str] = None) -> BuildConfi
     metadata_path = resolve_iib_build_metadata_path(context_path, metadata_file_path)
     metadata = load_iib_build_metadata(metadata_path)
 
+    raw_opm_version = metadata.get('opm_version')
     opm_version = opm_version_from_metadata(metadata)
     if opm_version is None:
-        raise IIBError(f"opm_version is required in {metadata_path}")
-    logger.info("OPM version %s loaded from %s", opm_version, metadata_path)
+        raise IIBError(
+            f'opm_version is required in {metadata_path}'
+        )
+    logger.info(
+        'OPM version %s loaded from %s (raw: %r)',
+        opm_version,
+        metadata_path,
+        raw_opm_version,
+    )
 
     labels = labels_from_metadata(metadata)
     if labels is None:

--- a/tests/unit/test_multi_arch_builder.py
+++ b/tests/unit/test_multi_arch_builder.py
@@ -167,8 +167,12 @@ class TestRunCmd:
 
 
 class TestGenerateCacheLocally:
+    @patch(
+        "multi_arch_builder.resolve_opm_binary_path",
+        return_value="/usr/bin/opm-v1.40.0",
+    )
     @patch("multi_arch_builder.run_cmd")
-    def test_runs_opm_command_with_correct_args(self, mock_run_cmd, tmp_path):
+    def test_runs_opm_command_with_correct_args(self, mock_run_cmd, mock_resolve, tmp_path):
         fbc_dir = tmp_path / "fbc"
         fbc_dir.mkdir()
         cache_dir = tmp_path / "cache"
@@ -194,8 +198,14 @@ class TestGenerateCacheLocally:
         assert "--cache-only" in cmd_arg
         assert f"--cache-dir={cache_dir}" in cmd_arg
 
+    @patch(
+        "multi_arch_builder.resolve_opm_binary_path",
+        return_value="/usr/bin/opm-v1.40.0",
+    )
     @patch("multi_arch_builder.run_cmd")
-    def test_cleans_existing_cache_directory_before_running(self, mock_run_cmd, tmp_path):
+    def test_cleans_existing_cache_directory_before_running(
+        self, mock_run_cmd, mock_resolve, tmp_path
+    ):
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
         stale_file = cache_dir / "stale.txt"
@@ -220,8 +230,14 @@ class TestGenerateCacheLocally:
         assert not stale_subdir.exists()
         assert (cache_dir / "new.db").exists()
 
+    @patch(
+        "multi_arch_builder.resolve_opm_binary_path",
+        return_value="/usr/bin/opm-v1.40.0",
+    )
     @patch("multi_arch_builder.run_cmd")
-    def test_raises_iib_error_when_cache_directory_empty_after_run(self, mock_run_cmd, tmp_path):
+    def test_raises_iib_error_when_cache_directory_empty_after_run(
+        self, mock_run_cmd, mock_resolve, tmp_path
+    ):
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
         # run_cmd does nothing → cache dir remains empty
@@ -234,8 +250,14 @@ class TestGenerateCacheLocally:
                 opm_version="v1.40.0",
             )
 
+    @patch(
+        "multi_arch_builder.resolve_opm_binary_path",
+        return_value="/usr/bin/opm-v1.40.0",
+    )
     @patch("multi_arch_builder.run_cmd")
-    def test_raises_iib_error_when_cache_directory_does_not_exist(self, mock_run_cmd, tmp_path):
+    def test_raises_iib_error_when_cache_directory_does_not_exist(
+        self, mock_run_cmd, mock_resolve, tmp_path
+    ):
         non_existent = str(tmp_path / "no_such_cache")
 
         with pytest.raises(mab.IIBError, match="Cannot access cache directory"):
@@ -246,8 +268,12 @@ class TestGenerateCacheLocally:
                 opm_version="v1.40.0",
             )
 
+    @patch(
+        "multi_arch_builder.resolve_opm_binary_path",
+        return_value="/usr/bin/opm-v1.99.0",
+    )
     @patch("multi_arch_builder.run_cmd")
-    def test_uses_opm_version_argument(self, mock_run_cmd, tmp_path):
+    def test_uses_opm_version_argument(self, mock_run_cmd, mock_resolve, tmp_path):
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
 
@@ -597,8 +623,31 @@ class TestOpmVersionFromMetadata:
     def test_returns_version_without_prefix(self):
         assert mab.opm_version_from_metadata({"opm_version": "v1.40.0"}) == "v1.40.0"
 
+    def test_maps_bare_opm_to_default(self):
+        assert mab.opm_version_from_metadata({"opm_version": "opm"}) == mab.DEFAULT_OPM_VERSION
+
+    def test_raises_when_opm_version_empty(self):
+        with pytest.raises(mab.IIBError, match="must not be empty"):
+            mab.opm_version_from_metadata({"opm_version": ""})
+
+    def test_raises_when_opm_version_whitespace_only(self):
+        with pytest.raises(mab.IIBError, match="must not be empty"):
+            mab.opm_version_from_metadata({"opm_version": "   "})
+
     def test_returns_none_when_missing(self):
         assert mab.opm_version_from_metadata({}) is None
+
+
+class TestResolveOpmBinaryPath:
+    @patch.object(mab.Path, "is_file", return_value=True)
+    def test_returns_path_when_binary_exists(self, mock_is_file):
+        assert mab.resolve_opm_binary_path("v1.48.0") == "/usr/bin/opm-v1.48.0"
+        mock_is_file.assert_called_once()
+
+    @patch.object(mab.Path, "is_file", return_value=False)
+    def test_raises_when_binary_missing(self, mock_is_file):
+        with pytest.raises(mab.IIBError, match="OPM binary not found"):
+            mab.resolve_opm_binary_path("v9.99.9")
 
 
 class TestLabelsFromMetadata:
@@ -746,6 +795,20 @@ class TestLoadConfigFromEnv:
         monkeypatch.setenv("CONTEXT", str(context))
 
         with pytest.raises(mab.IIBError, match="opm_version is required"):
+            mab.load_config_from_env()
+
+    def test_raises_when_opm_version_empty(self, tmp_path, monkeypatch):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        (context / ".iib-build-metadata.json").write_text(
+            json.dumps({"opm_version": "", "arches": ["amd64"]}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("IMAGE", "quay.io/org/img:latest")
+        monkeypatch.setenv("COMMIT_SHA", "sha123")
+        monkeypatch.setenv("CONTEXT", str(context))
+
+        with pytest.raises(mab.IIBError, match="must not be empty"):
             mab.load_config_from_env()
 
     def test_raises_when_arches_missing(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Signed-off-by: Jan Lipovský <jlipovsk@redhat.com>
Assisted-by: Cursor

[CLOUDDST-32654]

## Summary

Fix loading of opm version for binary less index images.

## Related Issues

<!-- Link to related issues: Fixes #123 -->

## Testing

- [x] Tests added/updated
- [x] All tests pass (`pytest`)

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated if needed
