### PR TITLE
fix: normalise configs and cache permissions before opm cache generation

### DIFF
--- a/task/iib-image-builder-oci-ta/multi-arch-builder.py
+++ b/task/iib-image-builder-oci-ta/multi-arch-builder.py
@@ -668,12 +668,40 @@ class MultiArchBuilder:
             raise IIBError(f"Catalog directory not found at {catalog_dir}")
 
         logger.info(f"Found catalog directory at {catalog_dir}")
-        generate_cache_locally(
-            base_dir=self.config.context_path,
-            fbc_dir=str(catalog_dir),
-            local_cache_path=self.config.cache_dir,
-            opm_version=self.config.opm_version,
-        )
+
+        logger.debug("Normalising permissions under %s", catalog_dir)
+        # Dockerfile COPY normalizes the root destination directory to mode 0755
+        # regardless of the source mode.  opm includes directory modes in its
+        # cache digest, so the modes at generation time must match what will
+        # appear in the final image after COPY — otherwise the runtime integrity
+        # check fails.  Normalise every directory to 0755 and every file to 0644
+        # so the digest is stable regardless of the source umask.
+        for dirpath, _dirnames, filenames in os.walk(str(catalog_dir)):
+            os.chmod(dirpath, 0o755)
+            for fname in filenames:
+                os.chmod(os.path.join(dirpath, fname), 0o644)
+
+        # OpenShift emptyDir volumes carry the setgid bit (mode 2777) and pods
+        # often run with a restrictive umask (e.g. 0027), so opm creates cache
+        # entries with non-standard modes (2750 dirs, 0640 files).  Dockerfile
+        # COPY then normalises the root to 0755, making the runtime digest
+        # diverge from the stored one.  Strip setgid from the cache mount and
+        # force umask 0022 so opm writes standard 0755/0644 entries whose
+        # digest survives COPY.
+        cache_path = Path(self.config.cache_dir)
+        if cache_path.exists():
+            os.chmod(str(cache_path), 0o755)
+        old_umask = os.umask(0o022)
+
+        try:
+            generate_cache_locally(
+                base_dir=self.config.context_path,
+                fbc_dir=str(catalog_dir),
+                local_cache_path=self.config.cache_dir,
+                opm_version=self.config.opm_version,
+            )
+        finally:
+            os.umask(old_umask)
 
         # Copy cache into build context so Dockerfile can access it
         logger.info("Copying cache into build context")

--- a/tests/unit/test_multi_arch_builder.py
+++ b/tests/unit/test_multi_arch_builder.py
@@ -488,6 +488,106 @@ class TestBuildImage:
 
 
 # ---------------------------------------------------------------------------
+# MultiArchBuilder.build_all – catalog dir permission normalization
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAllNormalizesConfigsPermissions:
+    """Dockerfile COPY normalises permissions: root dirs become 0755.
+
+    opm includes file and directory modes in its cache digest, so every
+    entry under ``configs/`` must be normalised before cache generation
+    to match what the runtime image will see after COPY.
+    """
+
+    @patch("multi_arch_builder.MultiArchBuilder._create_and_push_manifest_list")
+    @patch("multi_arch_builder.MultiArchBuilder._build_image")
+    @patch("multi_arch_builder.generate_cache_locally")
+    @patch("multi_arch_builder.MultiArchBuilder._prepare_system")
+    @patch("multi_arch_builder.run_cmd")
+    def test_catalog_tree_normalised_before_cache_generation(
+        self,
+        mock_run_cmd,
+        mock_prepare,
+        mock_gen_cache,
+        mock_build,
+        mock_manifest,
+        tmp_path,
+    ):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        catalog = context / "configs"
+        catalog.mkdir(mode=0o775)
+        subdir = catalog / "operator-a"
+        subdir.mkdir(mode=0o775)
+        gitkeep = catalog / ".gitkeep"
+        gitkeep.touch()
+        gitkeep.chmod(0o664)
+        catalog_json = subdir / "catalog.json"
+        catalog_json.write_text("{}")
+        catalog_json.chmod(0o664)
+
+        # Simulate OpenShift emptyDir with setgid (mode 2777)
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir(mode=0o2777)
+
+        dockerfile = context / "Dockerfile"
+        dockerfile.write_text("FROM scratch\n")
+
+        cfg = mab.BuildConfig(
+            image_name="quay.io/org/img:latest",
+            dockerfile_path=str(dockerfile),
+            context_path=str(context),
+            platforms=["amd64"],
+            labels=[],
+            cache_dir=str(cache_dir),
+            commit_sha="abc123",
+            opm_version="v1.40.0",
+        )
+        builder = mab.MultiArchBuilder(cfg)
+
+        observed = {}
+
+        def capture_modes(*args, **kwargs):
+            observed["catalog_dir"] = catalog.stat().st_mode & 0o7777
+            observed["subdir"] = subdir.stat().st_mode & 0o7777
+            observed["gitkeep"] = gitkeep.stat().st_mode & 0o7777
+            observed["catalog_json"] = catalog_json.stat().st_mode & 0o7777
+            observed["cache_dir"] = cache_dir.stat().st_mode & 0o7777
+            current_umask = os.umask(0)
+            os.umask(current_umask)
+            observed["umask"] = current_umask
+            (cache_dir / "cache").mkdir(exist_ok=True)
+            (cache_dir / "cache" / "packages.json").write_text("{}")
+            (cache_dir / "digest").write_text("abc")
+
+        mock_gen_cache.side_effect = capture_modes
+        mock_run_cmd.return_value = '{"Digest": "sha256:abc"}'
+
+        umask_before = os.umask(0o022)
+        os.umask(umask_before)
+
+        builder.build_all()
+
+        umask_after = os.umask(0o022)
+        os.umask(umask_after)
+        assert umask_after == umask_before, (
+            f"umask not restored after build_all(): was {umask_before:04o}, now {umask_after:04o}"
+        )
+
+        assert observed["catalog_dir"] == 0o755
+        assert observed["subdir"] == 0o755
+        assert observed["gitkeep"] == 0o644
+        assert observed["catalog_json"] == 0o644
+        assert observed["cache_dir"] == 0o755, (
+            f"cache_dir should be 0755 (setgid stripped), got {observed['cache_dir']:04o}"
+        )
+        assert observed["umask"] == 0o022, (
+            f"umask should be 0022 during cache generation, got {observed['umask']:04o}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # MultiArchBuilder._create_and_push_manifest_list
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
opm includes file and directory modes in its cache digest.  Two sources of permission mismatch caused "cache requires rebuild" at runtime:

1. Configs tree: source files may carry non-standard modes (e.g. 0775 dirs, 0664 files) depending on the upstream umask.  Dockerfile COPY normalises the root destination to 0755, but opm already recorded the digest with the original modes.  Fix: walk the configs tree and normalise every directory to 0755 and every file to 0644 before cache generation.

2. Cache directory: OpenShift emptyDir volumes carry the setgid bit (mode 2777) and pods run with a restrictive umask (0027), so opm creates cache entries with non-standard modes (2750 dirs, 0640 files).  Dockerfile COPY then normalises the root to 0755, making the runtime digest diverge.  Fix: strip setgid from the cache mount and force umask 0022 during cache generation.


