### PR TITLE
feat: skip OPM cache generation for regenerate-bundle requests

### DIFF
--- a/task/iib-image-builder-oci-ta/README.md
+++ b/task/iib-image-builder-oci-ta/README.md
@@ -36,10 +36,11 @@ Place a JSON file in the build context (default: `.iib-build-metadata.json`). Re
 
 | Field | Required | Description |
 |---|---|---|
-| `opm_version` | yes | OPM version for cache generation. Accepts `v1.48.0`, `opm-v1.48.0`, or IIB's default `opm` (see [opm_version normalization](#opm_version-normalization) below). Must not be empty. |
+| `opm_version` | yes* | OPM version for cache generation. Accepts `v1.48.0`, `opm-v1.48.0`, or IIB's default `opm` (see [opm_version normalization](#opm_version-normalization) below). Must not be empty. *Not required for regenerate-bundle requests (see below). |
 | `arches` | yes | Target architectures, e.g. `["amd64", "arm64", "ppc64le", "s390x"]` |
 | `labels` | no | Object of label key/value pairs applied to built images |
 | `binary_image` | no | Passed to the Dockerfile as `BINARY_IMAGE` build arg |
+| `package_name` | no | When present, signals a **regenerate-bundle** request. OPM cache generation, `configs/` directory, and `opm_version` are not required — the build proceeds directly from the Dockerfile. |
 
 Example:
 

--- a/task/iib-image-builder-oci-ta/multi-arch-builder.py
+++ b/task/iib-image-builder-oci-ta/multi-arch-builder.py
@@ -145,6 +145,7 @@ class BuildConfig:
     commit_sha: str
     opm_version: str
     binary_image: str = ""
+    skip_opm_cache: bool = False
     # Architecture mapping for platform names to expected architecture values
     arch_map: Dict[str, str] = field(
         default_factory=lambda: {
@@ -661,59 +662,62 @@ class MultiArchBuilder:
         # Prepare system
         self._prepare_system()
 
-        # Generate cache using OPM
-        logger.info("Generating cache using OPM")
-        catalog_dir = Path(self.config.context_path) / "configs"
-        if not catalog_dir.exists():
-            raise IIBError(f"Catalog directory not found at {catalog_dir}")
+        if self.config.skip_opm_cache:
+            logger.info("Skipping OPM cache generation (regenerate-bundle request)")
+        else:
+            # Generate cache using OPM
+            logger.info("Generating cache using OPM")
+            catalog_dir = Path(self.config.context_path) / "configs"
+            if not catalog_dir.exists():
+                raise IIBError(f"Catalog directory not found at {catalog_dir}")
 
-        logger.info(f"Found catalog directory at {catalog_dir}")
+            logger.info(f"Found catalog directory at {catalog_dir}")
 
-        logger.debug("Normalising permissions under %s", catalog_dir)
-        # Dockerfile COPY normalizes the root destination directory to mode 0755
-        # regardless of the source mode.  opm includes directory modes in its
-        # cache digest, so the modes at generation time must match what will
-        # appear in the final image after COPY — otherwise the runtime integrity
-        # check fails.  Normalise every directory to 0755 and every file to 0644
-        # so the digest is stable regardless of the source umask.
-        for dirpath, _dirnames, filenames in os.walk(str(catalog_dir)):
-            os.chmod(dirpath, 0o755)
-            for fname in filenames:
-                os.chmod(os.path.join(dirpath, fname), 0o644)
+            logger.debug("Normalising permissions under %s", catalog_dir)
+            # Dockerfile COPY normalizes the root destination directory to mode 0755
+            # regardless of the source mode.  opm includes directory modes in its
+            # cache digest, so the modes at generation time must match what will
+            # appear in the final image after COPY — otherwise the runtime integrity
+            # check fails.  Normalise every directory to 0755 and every file to 0644
+            # so the digest is stable regardless of the source umask.
+            for dirpath, _dirnames, filenames in os.walk(str(catalog_dir)):
+                os.chmod(dirpath, 0o755)
+                for fname in filenames:
+                    os.chmod(os.path.join(dirpath, fname), 0o644)
 
-        # OpenShift emptyDir volumes carry the setgid bit (mode 2777) and pods
-        # often run with a restrictive umask (e.g. 0027), so opm creates cache
-        # entries with non-standard modes (2750 dirs, 0640 files).  Dockerfile
-        # COPY then normalises the root to 0755, making the runtime digest
-        # diverge from the stored one.  Strip setgid from the cache mount and
-        # force umask 0022 so opm writes standard 0755/0644 entries whose
-        # digest survives COPY.
-        cache_path = Path(self.config.cache_dir)
-        if cache_path.exists():
-            os.chmod(str(cache_path), 0o755)
-        old_umask = os.umask(0o022)
+            # OpenShift emptyDir volumes carry the setgid bit (mode 2777) and pods
+            # often run with a restrictive umask (e.g. 0027), so opm creates cache
+            # entries with non-standard modes (2750 dirs, 0640 files).  Dockerfile
+            # COPY then normalises the root to 0755, making the runtime digest
+            # diverge from the stored one.  Strip setgid from the cache mount and
+            # force umask 0022 so opm writes standard 0755/0644 entries whose
+            # digest survives COPY.
+            cache_path = Path(self.config.cache_dir)
+            if cache_path.exists():
+                os.chmod(str(cache_path), 0o755)
+            old_umask = os.umask(0o022)
 
-        try:
-            generate_cache_locally(
-                base_dir=self.config.context_path,
-                fbc_dir=str(catalog_dir),
-                local_cache_path=self.config.cache_dir,
-                opm_version=self.config.opm_version,
-            )
-        finally:
-            os.umask(old_umask)
+            try:
+                generate_cache_locally(
+                    base_dir=self.config.context_path,
+                    fbc_dir=str(catalog_dir),
+                    local_cache_path=self.config.cache_dir,
+                    opm_version=self.config.opm_version,
+                )
+            finally:
+                os.umask(old_umask)
 
-        # Copy cache into build context so Dockerfile can access it
-        logger.info("Copying cache into build context")
-        context_cache_dir = Path(self.config.context_path) / "cache"
-        try:
-            if context_cache_dir.exists():
-                shutil.rmtree(context_cache_dir)
-            shutil.copytree(self.config.cache_dir, context_cache_dir)
-            logger.info(f"✓ Cache copied to {context_cache_dir}")
-        except (OSError, IOError) as e:
-            logger.error(f"Failed to copy cache to build context: {e}")
-            raise IIBError(f"Failed to copy cache to build context: {e}")
+            # Copy cache into build context so Dockerfile can access it
+            logger.info("Copying cache into build context")
+            context_cache_dir = Path(self.config.context_path) / "cache"
+            try:
+                if context_cache_dir.exists():
+                    shutil.rmtree(context_cache_dir)
+                shutil.copytree(self.config.cache_dir, context_cache_dir)
+                logger.info(f"✓ Cache copied to {context_cache_dir}")
+            except (OSError, IOError) as e:
+                logger.error(f"Failed to copy cache to build context: {e}")
+                raise IIBError(f"Failed to copy cache to build context: {e}")
 
         # Build images for each platform
         platform_images = []
@@ -789,16 +793,21 @@ def load_config_from_env(metadata_file_path: Optional[str] = None) -> BuildConfi
     metadata_path = resolve_iib_build_metadata_path(context_path, metadata_file_path)
     metadata = load_iib_build_metadata(metadata_path)
 
+    is_regenerate_bundle = "package_name" in metadata
+    if is_regenerate_bundle:
+        logger.info("Detected regenerate-bundle request (package_name present in metadata)")
+
     raw_opm_version = metadata.get("opm_version")
     opm_version = opm_version_from_metadata(metadata)
-    if opm_version is None:
+    if opm_version is None and not is_regenerate_bundle:
         raise IIBError(f"opm_version is required in {metadata_path}")
-    logger.info(
-        "OPM version %s loaded from %s (raw: %r)",
-        opm_version,
-        metadata_path,
-        raw_opm_version,
-    )
+    if opm_version:
+        logger.info(
+            "OPM version %s loaded from %s (raw: %r)",
+            opm_version,
+            metadata_path,
+            raw_opm_version,
+        )
 
     labels = labels_from_metadata(metadata)
     if labels is None:
@@ -828,8 +837,9 @@ def load_config_from_env(metadata_file_path: Optional[str] = None) -> BuildConfi
         labels=labels,
         cache_dir=os.environ.get("CACHE_DIR", "/var/workdir/cache"),
         commit_sha=os.environ.get("COMMIT_SHA", ""),
-        opm_version=opm_version,
+        opm_version=opm_version or "",
         binary_image=binary_image,
+        skip_opm_cache=is_regenerate_bundle,
     )
 
 

--- a/task/iib-image-builder-oci-ta/multi-arch-builder.py
+++ b/task/iib-image-builder-oci-ta/multi-arch-builder.py
@@ -796,12 +796,13 @@ def load_config_from_env(metadata_file_path: Optional[str] = None) -> BuildConfi
     is_regenerate_bundle = "package_name" in metadata
     if is_regenerate_bundle:
         logger.info("Detected regenerate-bundle request (package_name present in metadata)")
-
-    raw_opm_version = metadata.get("opm_version")
-    opm_version = opm_version_from_metadata(metadata)
-    if opm_version is None and not is_regenerate_bundle:
-        raise IIBError(f"opm_version is required in {metadata_path}")
-    if opm_version:
+        opm_version = ""
+        logger.info("No OPM version required for regenerate-bundle request")
+    else:
+        raw_opm_version = metadata.get("opm_version")
+        opm_version = opm_version_from_metadata(metadata)
+        if opm_version is None:
+            raise IIBError(f"opm_version is required in {metadata_path}")
         logger.info(
             "OPM version %s loaded from %s (raw: %r)",
             opm_version,

--- a/tests/unit/test_multi_arch_builder.py
+++ b/tests/unit/test_multi_arch_builder.py
@@ -317,6 +317,19 @@ class TestBuildConfig:
             "s390x": "s390x",
         }
 
+    def test_skip_opm_cache_defaults_to_false(self):
+        cfg = mab.BuildConfig(
+            image_name="img:tag",
+            dockerfile_path="/Dockerfile",
+            context_path="/ctx",
+            platforms=["amd64"],
+            labels=[],
+            cache_dir="/cache",
+            commit_sha="sha",
+            opm_version="v1.40.0",
+        )
+        assert cfg.skip_opm_cache is False
+
     def test_custom_arch_map(self):
         custom_map = {"amd64": "x86_64"}
         cfg = mab.BuildConfig(
@@ -585,6 +598,134 @@ class TestBuildAllNormalizesConfigsPermissions:
         assert observed["umask"] == 0o022, (
             f"umask should be 0022 during cache generation, got {observed['umask']:04o}"
         )
+
+
+# ---------------------------------------------------------------------------
+# MultiArchBuilder.build_all – skip OPM cache for regenerate-bundle
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAllSkipsOpmCacheForRegenerateBundle:
+    @patch("multi_arch_builder.MultiArchBuilder._create_and_push_manifest_list")
+    @patch("multi_arch_builder.MultiArchBuilder._build_image")
+    @patch("multi_arch_builder.generate_cache_locally")
+    @patch("multi_arch_builder.MultiArchBuilder._prepare_system")
+    @patch("multi_arch_builder.run_cmd")
+    def test_skips_cache_generation_when_skip_opm_cache_is_true(
+        self,
+        mock_run_cmd,
+        mock_prepare,
+        mock_gen_cache,
+        mock_build,
+        mock_manifest,
+        tmp_path,
+    ):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        dockerfile = context / "Dockerfile"
+        dockerfile.write_text("FROM scratch\n")
+
+        cfg = mab.BuildConfig(
+            image_name="quay.io/org/img:latest",
+            dockerfile_path=str(dockerfile),
+            context_path=str(context),
+            platforms=["amd64"],
+            labels=[],
+            cache_dir=str(tmp_path / "cache"),
+            commit_sha="abc123",
+            opm_version="",
+            skip_opm_cache=True,
+        )
+        builder = mab.MultiArchBuilder(cfg)
+        mock_run_cmd.return_value = '{"Digest": "sha256:abc"}'
+
+        builder.build_all()
+
+        mock_gen_cache.assert_not_called()
+
+    @patch("multi_arch_builder.MultiArchBuilder._create_and_push_manifest_list")
+    @patch("multi_arch_builder.MultiArchBuilder._build_image")
+    @patch("multi_arch_builder.generate_cache_locally")
+    @patch("multi_arch_builder.MultiArchBuilder._prepare_system")
+    @patch("multi_arch_builder.run_cmd")
+    def test_does_not_require_configs_directory_when_skip_opm_cache(
+        self,
+        mock_run_cmd,
+        mock_prepare,
+        mock_gen_cache,
+        mock_build,
+        mock_manifest,
+        tmp_path,
+    ):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        dockerfile = context / "Dockerfile"
+        dockerfile.write_text("FROM scratch\n")
+
+        cfg = mab.BuildConfig(
+            image_name="quay.io/org/img:latest",
+            dockerfile_path=str(dockerfile),
+            context_path=str(context),
+            platforms=["amd64"],
+            labels=[],
+            cache_dir=str(tmp_path / "cache"),
+            commit_sha="abc123",
+            opm_version="",
+            skip_opm_cache=True,
+        )
+        builder = mab.MultiArchBuilder(cfg)
+        mock_run_cmd.return_value = '{"Digest": "sha256:abc"}'
+
+        builder.build_all()
+
+        mock_build.assert_called_once()
+
+    @patch("multi_arch_builder.MultiArchBuilder._create_and_push_manifest_list")
+    @patch("multi_arch_builder.MultiArchBuilder._build_image")
+    @patch("multi_arch_builder.generate_cache_locally")
+    @patch("multi_arch_builder.MultiArchBuilder._prepare_system")
+    @patch("multi_arch_builder.run_cmd")
+    def test_still_generates_cache_when_skip_opm_cache_is_false(
+        self,
+        mock_run_cmd,
+        mock_prepare,
+        mock_gen_cache,
+        mock_build,
+        mock_manifest,
+        tmp_path,
+    ):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        catalog = context / "configs"
+        catalog.mkdir()
+        (catalog / "catalog.json").write_text("{}")
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        dockerfile = context / "Dockerfile"
+        dockerfile.write_text("FROM scratch\n")
+
+        cfg = mab.BuildConfig(
+            image_name="quay.io/org/img:latest",
+            dockerfile_path=str(dockerfile),
+            context_path=str(context),
+            platforms=["amd64"],
+            labels=[],
+            cache_dir=str(cache_dir),
+            commit_sha="abc123",
+            opm_version="v1.40.0",
+            skip_opm_cache=False,
+        )
+        builder = mab.MultiArchBuilder(cfg)
+
+        def populate_cache(*args, **kwargs):
+            (cache_dir / "packages.json").write_text("{}")
+
+        mock_gen_cache.side_effect = populate_cache
+        mock_run_cmd.return_value = '{"Digest": "sha256:abc"}'
+
+        builder.build_all()
+
+        mock_gen_cache.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -924,6 +1065,38 @@ class TestLoadConfigFromEnv:
 
         with pytest.raises(mab.IIBError, match="arches is required"):
             mab.load_config_from_env()
+
+    def test_regenerate_bundle_does_not_require_opm_version(self, tmp_path, monkeypatch):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        (context / ".iib-build-metadata.json").write_text(
+            json.dumps({"arches": ["amd64"], "package_name": "my-operator"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("IMAGE", "quay.io/org/img:latest")
+        monkeypatch.setenv("COMMIT_SHA", "sha123")
+        monkeypatch.setenv("CONTEXT", str(context))
+
+        cfg = mab.load_config_from_env()
+        assert cfg.opm_version == ""
+
+    def test_regenerate_bundle_sets_skip_opm_cache(self, tmp_path, monkeypatch):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        (context / ".iib-build-metadata.json").write_text(
+            json.dumps({"arches": ["amd64"], "package_name": "my-operator"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("IMAGE", "quay.io/org/img:latest")
+        monkeypatch.setenv("COMMIT_SHA", "sha123")
+        monkeypatch.setenv("CONTEXT", str(context))
+
+        cfg = mab.load_config_from_env()
+        assert cfg.skip_opm_cache is True
+
+    def test_non_regenerate_bundle_sets_skip_opm_cache_false(self, metadata_build_context):
+        cfg = mab.load_config_from_env()
+        assert cfg.skip_opm_cache is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_multi_arch_builder.py
+++ b/tests/unit/test_multi_arch_builder.py
@@ -1098,6 +1098,27 @@ class TestLoadConfigFromEnv:
         cfg = mab.load_config_from_env()
         assert cfg.skip_opm_cache is False
 
+    def test_regenerate_bundle_ignores_malformed_opm_version(self, tmp_path, monkeypatch):
+        context = tmp_path / "ctx"
+        context.mkdir()
+        (context / ".iib-build-metadata.json").write_text(
+            json.dumps(
+                {
+                    "arches": ["amd64"],
+                    "package_name": "my-operator",
+                    "opm_version": "",
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("IMAGE", "quay.io/org/img:latest")
+        monkeypatch.setenv("COMMIT_SHA", "sha123")
+        monkeypatch.setenv("CONTEXT", str(context))
+
+        cfg = mab.load_config_from_env()
+        assert cfg.opm_version == ""
+        assert cfg.skip_opm_cache is True
+
 
 # ---------------------------------------------------------------------------
 # main()


### PR DESCRIPTION
The regenerate-bundle request type (identified by the presence of `package_name` in .iib-build-metadata.json) does not use OPM and does not require a binary_image. It simply needs the index image built directly from the Dockerfile without any FBC cache generation.

Changes:
- Add `skip_opm_cache` field to BuildConfig (defaults to False)
- Detect regenerate-bundle requests in load_config_from_env() by checking for the `package_name` key in the metadata file
- When detected: opm_version is no longer mandatory, OPM cache generation is skipped entirely (including configs/ directory permission normalisation and cache copy into build context), and the build proceeds directly to building images from the Dockerfile
- binary_image was already optional and continues to work as-is; regenerate-bundle metadata simply won't include it

Tests:
- BuildConfig.skip_opm_cache defaults to False
- load_config_from_env: package_name skips opm_version requirement, sets skip_opm_cache=True, opm_version defaults to empty string
- load_config_from_env: normal metadata sets skip_opm_cache=False
- build_all: generate_cache_locally is not called when skip_opm_cache is True, configs/ directory is not required, and cache generation still runs when skip_opm_cache is False


