### PR TITLE
feat: push per-arch images in parallel before manifest list creation

### DIFF
--- a/task/iib-image-builder-oci-ta/multi-arch-builder.py
+++ b/task/iib-image-builder-oci-ta/multi-arch-builder.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass, field
@@ -117,9 +118,10 @@ def run_cmd(
             ):
                 raise IIBError("Error deleting packages from database")
         elif cmd[0] == "buildah":
-            # Check for HTTP 403 or 50X errors on buildah
+            # Check for transient network/registry errors on any buildah operation
             network_regexes = [
                 r".*([e,E]rror:? creating build container).*(:?(403|50[0-9]|125)\s?.*$)",
+                r".*((?:403 Forbidden|50[0-9] \w+).*$)",
                 r".*(read\/write on closed pipe.*$)",
             ]
             for regex in network_regexes:
@@ -493,7 +495,6 @@ class MultiArchBuilder:
             destination,
         )
 
-        # Prepare buildah command with improved options
         cmd = [
             "buildah",
             "bud",
@@ -513,20 +514,16 @@ class MultiArchBuilder:
             self.config.dockerfile_path,
         ]
 
-        # Add labels
         for label in self.config.labels:
             cmd.extend(["--label", label.strip()])
 
         if self.config.binary_image:
             cmd.extend(["--build-arg", f"BINARY_IMAGE={self.config.binary_image}"])
 
-        # Add context
         cmd.append(self.config.context_path)
 
-        # Execute build with retry logic
         run_cmd(cmd, {"timeout": 3600}, f"build for {arch} failed")
 
-        # Verify architecture was set correctly
         logger.debug("Verifying that %s was built with expected arch %s", destination, arch)
         self._verify_image_architecture(destination, arch)
 
@@ -537,9 +534,12 @@ class MultiArchBuilder:
         :param str image_name: the image name to verify
         :param str expected_arch: the expected architecture
         """
-
-        # Get image architecture using skopeo inspect
-        inspect_cmd = ["skopeo", "inspect", "--no-tags", f"containers-storage:{image_name}"]
+        inspect_cmd = [
+            "skopeo",
+            "inspect",
+            "--no-tags",
+            f"containers-storage:{image_name}",
+        ]
         result = run_cmd(inspect_cmd, {"timeout": 60}, f"inspect {image_name} failed")
         image_data = json.loads(result)
 
@@ -571,6 +571,43 @@ class MultiArchBuilder:
     @retry(
         before_sleep=before_sleep_log(logger, logging.WARNING),
         reraise=True,
+        retry=retry_if_exception_type(ExternalServiceError),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=2),
+    )
+    def _push_image(self, image: str) -> None:
+        """Push a single architecture image to the registry."""
+        logger.info("Pushing %s to registry", image)
+        cmd = [
+            "buildah",
+            "push",
+            "--tls-verify=true",
+            image,
+            f"docker://{image}",
+        ]
+        run_cmd(cmd, {"timeout": 3600}, exc_msg=f"Failed to push {image}")
+        logger.info("✓ Pushed %s", image)
+
+    def _verify_manifest_list(self, manifest_name: str, platform_images: List[str]) -> None:
+        """Verify the local manifest list contains all expected architectures."""
+        result = run_cmd(
+            ["buildah", "manifest", "inspect", manifest_name],
+            exc_msg=f"Failed to inspect manifest list {manifest_name}",
+        )
+        manifest_data = json.loads(result)
+        manifests = manifest_data.get("manifests", [])
+        found_arches = sorted(m.get("platform", {}).get("architecture", "") for m in manifests)
+        expected_arches = sorted(self.config.arch_map.get(p, p) for p in self.config.platforms)
+        if found_arches != expected_arches:
+            raise IIBError(
+                f"Manifest list {manifest_name} has architectures {found_arches}, "
+                f"expected {expected_arches}"
+            )
+        logger.info("✓ Manifest list %s verified: %s", manifest_name, ", ".join(found_arches))
+
+    @retry(
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
         retry=retry_if_exception_type(IIBError),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2),
@@ -587,55 +624,71 @@ class MultiArchBuilder:
         """
         buildah_manifest_cmd = ["buildah", "manifest"]
         image_name_repo, image_name_tag = self.config.image_name.split(":", 1)
-        # Initialize _tags with the output image tag
         _tags = [image_name_tag]
         if self.config.commit_sha:
             _tags.append(self.config.commit_sha)
 
-        output_pull_specs = []
-        for tag in _tags:
-            output_pull_spec = f"{image_name_repo}:{tag}"
-            output_pull_specs.append(output_pull_spec)
-            try:
-                run_cmd(
-                    buildah_manifest_cmd + ["rm", output_pull_spec],
-                    exc_msg=(
-                        f"Failed to remove local manifest list. {output_pull_spec} does not exist"
-                    ),
-                )
-            except IIBError as e:
-                error_msg = str(e)
-                if "Manifest list not found locally." not in error_msg:
-                    raise IIBError(f"Error removing local manifest list: {error_msg}")
-                logger.debug(
-                    "Manifest list cannot be removed. No manifest list %s found", output_pull_spec
-                )
-            logger.info("Creating the manifest list %s locally", output_pull_spec)
-            run_cmd(
-                buildah_manifest_cmd + ["create", output_pull_spec],
-                exc_msg=f"Failed to create the manifest list locally: {output_pull_spec}",
-            )
-            for arch_image in platform_images:
-                run_cmd(
-                    buildah_manifest_cmd + ["add", output_pull_spec, arch_image],
-                    exc_msg=(
-                        f"Failed to add {arch_image} to the local manifest list: {output_pull_spec}"
-                    ),
-                )
+        primary_pull_spec = f"{image_name_repo}:{_tags[0]}"
 
-            logger.debug("Pushing manifest list %s", output_pull_spec)
+        # Build and push the manifest list for the primary tag
+        try:
             run_cmd(
-                buildah_manifest_cmd
-                + [
-                    "push",
+                buildah_manifest_cmd + ["rm", primary_pull_spec],
+                exc_msg=(
+                    f"Failed to remove local manifest list. {primary_pull_spec} does not exist"
+                ),
+            )
+        except IIBError as e:
+            error_msg = str(e)
+            if "Manifest list not found locally." not in error_msg:
+                raise IIBError(f"Error removing local manifest list: {error_msg}")
+            logger.debug(
+                "Manifest list cannot be removed. No manifest list %s found",
+                primary_pull_spec,
+            )
+        logger.info("Creating the manifest list %s locally", primary_pull_spec)
+        run_cmd(
+            buildah_manifest_cmd + ["create", primary_pull_spec],
+            exc_msg=f"Failed to create the manifest list locally: {primary_pull_spec}",
+        )
+        for arch_image in platform_images:
+            run_cmd(
+                buildah_manifest_cmd + ["add", primary_pull_spec, f"docker://{arch_image}"],
+                exc_msg=(
+                    f"Failed to add {arch_image} to the local manifest list: {primary_pull_spec}"
+                ),
+            )
+
+        self._verify_manifest_list(primary_pull_spec, platform_images)
+
+        logger.debug("Pushing manifest list %s", primary_pull_spec)
+        run_cmd(
+            buildah_manifest_cmd
+            + [
+                "push",
+                "--all",
+                "--format",
+                "v2s2",
+                "--tls-verify=true",
+                primary_pull_spec,
+                f"docker://{primary_pull_spec}",
+            ],
+            exc_msg=f"Failed to push the manifest list to {primary_pull_spec}",
+        )
+
+        # Copy the manifest list to additional tags via skopeo (server-side)
+        for tag in _tags[1:]:
+            additional_pull_spec = f"{image_name_repo}:{tag}"
+            logger.info("Copying manifest list to %s", additional_pull_spec)
+            run_cmd(
+                [
+                    "skopeo",
+                    "copy",
                     "--all",
-                    "--format",
-                    "v2s2",
-                    "--tls-verify=true",
-                    output_pull_spec,
-                    f"docker://{output_pull_spec}",
+                    f"docker://{primary_pull_spec}",
+                    f"docker://{additional_pull_spec}",
                 ],
-                exc_msg=f"Failed to push the manifest list to {output_pull_spec}",
+                exc_msg=f"Failed to copy manifest list to {additional_pull_spec}",
             )
 
     def build_all(self, ca_bundle_path: Optional[str] = None) -> Dict[str, Any]:
@@ -715,18 +768,30 @@ class MultiArchBuilder:
             logger.error(f"Failed to copy cache to build context: {e}")
             raise IIBError(f"Failed to copy cache to build context: {e}")
 
-        # Build images for each platform
+        # Build and verify images sequentially, then push in parallel
         platform_images = []
         for platform in self.config.platforms:
-            try:
-                platform_clean = platform.strip()
-                # output-image:tag-platform
-                platform_image = f"{self.config.image_name}-{platform_clean}"
-                self._build_image(platform_clean, platform_image)
-                platform_images.append(platform_image)
-            except (IIBError, ExternalServiceError) as e:
-                logger.error(f"Failed to build for {platform}: {e}")
-                raise
+            platform_clean = platform.strip()
+            platform_image = f"{self.config.image_name}-{platform_clean}"
+            self._build_image(platform_clean, platform_image)
+            platform_images.append(platform_image)
+
+        # Push all per-arch images in parallel so registry layers are
+        # present before manifest list creation
+        logger.info("Pushing per-arch images in parallel")
+        with ThreadPoolExecutor(max_workers=len(platform_images)) as executor:
+            futures = {executor.submit(self._push_image, img): img for img in platform_images}
+            errors = {}
+            for future in as_completed(futures):
+                img = futures[future]
+                try:
+                    future.result()
+                except Exception as e:
+                    logger.error("Failed to push %s: %s", img, e)
+                    errors[img] = e
+            if errors:
+                failed = ", ".join(sorted(errors))
+                raise IIBError(f"Failed to push per-arch images: {failed}")
 
         # Create and push manifest
         logger.info("Creating and pushing multi-arch manifest")

--- a/tests/unit/test_multi_arch_builder.py
+++ b/tests/unit/test_multi_arch_builder.py
@@ -488,6 +488,122 @@ class TestBuildImage:
 
 
 # ---------------------------------------------------------------------------
+# MultiArchBuilder._push_image
+# ---------------------------------------------------------------------------
+
+
+class TestPushImage:
+    @patch("multi_arch_builder.run_cmd")
+    def test_executes_buildah_push_with_correct_flags(self, mock_run_cmd, builder):
+        builder._push_image.__wrapped__(builder, "quay.io/org/img:latest-amd64")
+        cmd = mock_run_cmd.call_args[0][0]
+        assert cmd == [
+            "buildah",
+            "push",
+            "--tls-verify=true",
+            "quay.io/org/img:latest-amd64",
+            "docker://quay.io/org/img:latest-amd64",
+        ]
+
+    @patch("multi_arch_builder.run_cmd", side_effect=mab.ExternalServiceError("503"))
+    def test_raises_external_service_error_on_network_failure(self, mock_run_cmd, builder):
+        with pytest.raises(mab.ExternalServiceError):
+            builder._push_image.__wrapped__(builder, "quay.io/org/img:latest-amd64")
+
+
+# ---------------------------------------------------------------------------
+# MultiArchBuilder._verify_manifest_list
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyManifestList:
+    @patch("multi_arch_builder.run_cmd")
+    def test_passes_when_all_arches_present(self, mock_run_cmd, builder):
+        builder.config.platforms = ["amd64", "arm64"]
+        mock_run_cmd.return_value = json.dumps(
+            {
+                "manifests": [
+                    {"platform": {"architecture": "amd64"}},
+                    {"platform": {"architecture": "arm64"}},
+                ]
+            }
+        )
+        builder._verify_manifest_list("quay.io/org/img:v1", ["img-amd64", "img-arm64"])
+
+    @patch("multi_arch_builder.run_cmd")
+    def test_raises_when_arch_missing(self, mock_run_cmd, builder):
+        builder.config.platforms = ["amd64", "arm64", "s390x"]
+        mock_run_cmd.return_value = json.dumps(
+            {
+                "manifests": [
+                    {"platform": {"architecture": "amd64"}},
+                    {"platform": {"architecture": "arm64"}},
+                ]
+            }
+        )
+        with pytest.raises(mab.IIBError, match="expected.*s390x"):
+            builder._verify_manifest_list("quay.io/org/img:v1", ["img-amd64", "img-arm64"])
+
+    @patch("multi_arch_builder.run_cmd")
+    def test_raises_when_extra_arch_present(self, mock_run_cmd, builder):
+        builder.config.platforms = ["amd64"]
+        mock_run_cmd.return_value = json.dumps(
+            {
+                "manifests": [
+                    {"platform": {"architecture": "amd64"}},
+                    {"platform": {"architecture": "arm64"}},
+                ]
+            }
+        )
+        with pytest.raises(mab.IIBError, match="expected"):
+            builder._verify_manifest_list("quay.io/org/img:v1", ["img-amd64"])
+
+    @patch("multi_arch_builder.MultiArchBuilder._create_and_push_manifest_list")
+    @patch("multi_arch_builder.MultiArchBuilder._build_image")
+    @patch("multi_arch_builder.generate_cache_locally")
+    @patch("multi_arch_builder.MultiArchBuilder._prepare_system")
+    @patch("multi_arch_builder.run_cmd")
+    def test_parallel_push_reports_all_failures(
+        self,
+        mock_run_cmd,
+        mock_prepare,
+        mock_gen_cache,
+        mock_build,
+        mock_manifest,
+        builder,
+        tmp_path,
+    ):
+        """When multiple arch pushes fail, all are reported before raising."""
+        context = tmp_path / "ctx"
+        context.mkdir()
+        (context / "configs").mkdir()
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        dockerfile = context / "Dockerfile"
+        dockerfile.write_text("FROM scratch\n")
+        builder.config.context_path = str(context)
+        builder.config.dockerfile_path = str(dockerfile)
+        builder.config.cache_dir = str(cache_dir)
+        builder.config.platforms = ["amd64", "arm64"]
+
+        def run_cmd_side_effect(cmd, *args, **kwargs):
+            if cmd[0] == "buildah" and "push" in cmd:
+                raise mab.IIBError(f"push failed for {cmd[-1]}")
+            return '{"Digest": "sha256:abc"}'
+
+        mock_run_cmd.side_effect = run_cmd_side_effect
+        mock_gen_cache.side_effect = lambda *a, **kw: (
+            (cache_dir / "cache").mkdir(exist_ok=True),
+            (cache_dir / "cache" / "pkg.json").write_text("{}"),
+            (cache_dir / "digest").write_text("abc"),
+        )
+
+        with pytest.raises(mab.IIBError, match="Failed to push per-arch images"):
+            builder.build_all()
+        mock_manifest.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # MultiArchBuilder.build_all – catalog dir permission normalization
 # ---------------------------------------------------------------------------
 
@@ -593,28 +709,40 @@ class TestBuildAllNormalizesConfigsPermissions:
 
 
 class TestCreateAndPushManifestList:
+    @staticmethod
+    def _manifest_inspect_json(arches):
+        return json.dumps({"manifests": [{"platform": {"architecture": a}} for a in arches]})
+
     @patch("multi_arch_builder.run_cmd")
-    def test_creates_and_pushes_manifest_for_each_tag(self, mock_run_cmd, builder):
-        """With a commit_sha, two tags should be created and pushed."""
+    def test_creates_manifest_and_copies_to_second_tag(self, mock_run_cmd, builder):
+        """With a commit_sha, primary tag is built+pushed, second is skopeo-copied."""
         builder.config.image_name = "quay.io/org/img:latest"
         builder.config.commit_sha = "abc123"
         platform_images = [
             "quay.io/org/img:latest-amd64",
             "quay.io/org/img:latest-arm64",
         ]
-        # First call (rm) raises IIBError("Manifest list not found locally.") → tolerated
 
         def side_effect(cmd, *args, **kwargs):
             if "rm" in cmd:
                 raise mab.IIBError("Manifest list not found locally.")
+            if "inspect" in cmd:
+                return self._manifest_inspect_json(["amd64", "arm64"])
             return ""
 
         mock_run_cmd.side_effect = side_effect
-        # Should not raise
         builder._create_and_push_manifest_list.__wrapped__(builder, platform_images)
 
-        # Expect: for each of 2 tags → rm + create + 2×add + push = 5 calls × 2 = 10
-        assert mock_run_cmd.call_count == 10
+        # Primary tag: rm + create + 2×add + inspect + push = 6
+        # Second tag: 1 skopeo copy = 7 total
+        assert mock_run_cmd.call_count == 7
+        # Last call should be skopeo copy
+        last_cmd = mock_run_cmd.call_args_list[-1][0][0]
+        assert last_cmd[0] == "skopeo"
+        assert "copy" in last_cmd
+        assert "--all" in last_cmd
+        assert "docker://quay.io/org/img:latest" in last_cmd
+        assert "docker://quay.io/org/img:abc123" in last_cmd
 
     @patch("multi_arch_builder.run_cmd")
     def test_removes_existing_manifest_before_creating(self, mock_run_cmd, builder):
@@ -627,6 +755,8 @@ class TestCreateAndPushManifestList:
             if "rm" in cmd:
                 rm_attempted.append(True)
                 raise mab.IIBError("Manifest list not found locally.")
+            if "inspect" in cmd:
+                return self._manifest_inspect_json(["amd64", "arm64"])
             return ""
 
         mock_run_cmd.side_effect = side_effect
@@ -659,10 +789,12 @@ class TestCreateAndPushManifestList:
         push_cmds = []
 
         def side_effect(cmd, *args, **kwargs):
-            if "push" in cmd:
+            if cmd[0] == "buildah" and "push" in cmd:
                 push_cmds.append(cmd)
             if "rm" in cmd:
                 raise mab.IIBError("Manifest list not found locally.")
+            if "inspect" in cmd:
+                return self._manifest_inspect_json(["amd64", "arm64"])
             return ""
 
         mock_run_cmd.side_effect = side_effect


### PR DESCRIPTION
Per-arch images were only built locally and never pushed to the registry before manifest list creation. This meant `buildah manifest push --all` had to push all architecture image layers for the first time (~4.5 min), then repeat for the second tag. Now per-arch images are pushed in parallel via ThreadPoolExecutor before manifest creation, so `--all` finds layers already present and only pushes the manifest list metadata.


