### PR TITLE
Add SECURITY.md for CRA

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Reporting a Security Vulnerability or Incident for IIB
+
+Please do not report security vulnerabilities or security incidents via public channels (such as GitHub Issues or Pull Requests).
+
+To ensure coordinated disclosure, please email the IIB security team at _exd-guild-hello-operator-admins\[at\]redhat.com_ with a description of the issue, how to reproduce it and any mitigations you are aware of.
+
+If possible please include a proposed severity rating (for example, see [Red Hat's severity ratings](https://access.redhat.com/security/updates/classification)), and other classifying metadata such as a [CWE](https://cwe.mitre.org/) ID or a [CVSS](https://www.first.org/cvss/) score.
+
+## Response Timeline
+
+Our security team will respond within three working days of your email.
+
+## Submission Guidelines
+
+To help us triage and resolve the issue efficiently, please include the following in your report:
+
+- **Title**: A concise, descriptive summary of the issue.
+- **Reporter Details**: Your name/handle and affiliation.
+- **Technical Description**: Detailed information regarding the vulnerability.
+- **Affected Versions**: The specific version(s) or range(s) of software tested.
+- **Reproduction Steps**: A minimal, functional example to reproduce the issue.
+- **Impact Assessment**: Potential exploit scenarios and perceived severity. (optional)
+- **Suggested Fix**: Any proposed patches or mitigations (optional).
+- **Disclosure Status**: Whether this has been shared with other parties or published and your plan for future sharing (e.g., at a conference).
+
+## Contact Information
+
+Direct all security questions and vulnerability reports to:
+
+- **Email**: _exd-guild-hello-operator-admins\[at\]redhat.com_
+
+## Security Policy
+
+Full details of Red Hat’s security disclosure and remediation process can be found here: <https://access.redhat.com/articles/red-hat-coordinated-vulnerability-disclosure>
+
+## EU Cyber Resilience Act — Open Source Steward Statement
+
+This project is stewarded by **Red Hat, Inc.**, an open source software steward as defined in Article 3(14) of the [EU Cyber Resilience Act (Regulation 2024/2847)](https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng).
+Contact: [cra-steward@redhat.com](mailto:cra-steward@redhat.com)
+
+Refer to [Red Hat's security practices and vulnerability management policy](https://access.redhat.com/security/) for detailed information.


### PR DESCRIPTION
Updated security policy for EU Cyber Resilience Act (CRA) requirements.

The EU Cyber Resilience Act (CRA) requires all in-scope repositories to have
a SECURITY.md file documenting vulnerability reporting procedures, steward
contact information, and Coordinated Vulnerability Disclosure (CVD) process.

More details can be found here:
http://red.ht/cra-steward